### PR TITLE
Fixed mojohaus/versions-maven-plugin#193

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,25 +5,25 @@
  * [Fixed Issue 182][issue-182]
 
    Add goal for updating the SCM tag in the POM.
-   
+
  * [Fixed Issue 197][issue-197]
- 
+
    Java 1.7 as prerequisite.
 
  * [Fixed Issue 198][issue-198]
- 
+
    Update version of modules which are not children but part of reactor.
 
  * [Fixed Issue 185][issue-185]
-   
+
    Unable to set dependencyReportFormat as parameter anymore.
    Thanks to Ilja Dubinin.
 
  * [Fixed Issue 187][issue-187]
-   
+
    create target directory when run dependency update report.
    Thanks to Ilja Dubinin.
-   
+
  * [Pull Request #189][pull-189]
 
    Fixed inccorect links. Thanks to Anton Johansson.

--- a/src/it/it-rules-via-classpath-001/invoker.properties
+++ b/src/it/it-rules-via-classpath-001/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases
+invoker.buildResult = failure

--- a/src/it/it-rules-via-classpath-001/pom.xml
+++ b/src/it/it-rules-via-classpath-001/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-rules-via-classpath-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>GH-193: Fail if resource is not found</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>version-rules</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rulesUri>classpath:///package/foo/bar/rule-set.xml</rulesUri>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-rules-via-classpath-001/verify.bsh
+++ b/src/it/it-rules-via-classpath-001/verify.bsh
@@ -1,0 +1,22 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "build.log" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+    String expectedMessage = "Resource \"classpath:///package/foo/bar/rule-set.xml\" not found in classpath.";
+
+    if ( buf.indexOf( expectedMessage ) < 0 )
+    {
+        System.err.println( "Build should have failed as the requested resource is not present." );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-rules-via-classpath-002/invoker.properties
+++ b/src/it/it-rules-via-classpath-002/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean install ${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases
+invoker.buildResult = success

--- a/src/it/it-rules-via-classpath-002/pom.xml
+++ b/src/it/it-rules-via-classpath-002/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-rules-via-classpath-002</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>GH-193: Succeed if resource is found</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>version-rules</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>setup-provide-rules-in-jar</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rulesUri>classpath:///package/foo/bar/rules.xml</rulesUri>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>setup-provide-rules-in-jar</artifactId>
+            <version>1.0</version>
+          </dependency>
+
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-rules-via-classpath-002/verify.bsh
+++ b/src/it/it-rules-via-classpath-002/verify.bsh
@@ -1,0 +1,22 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "build.log" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+    String expectedMessage = "Resource \"classpath:///package/foo/bar/rules.xml\" not found in classpath.";
+
+    if ( buf.indexOf( expectedMessage ) >= 0 )
+    {
+        System.err.println( "File resource rules.xml should have been found in the classpath." );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-rules-via-classpath-003/invoker.properties
+++ b/src/it/it-rules-via-classpath-003/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean install ${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases
+invoker.buildResult = success

--- a/src/it/it-rules-via-classpath-003/pom.xml
+++ b/src/it/it-rules-via-classpath-003/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-rules-via-classpath-003</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>GH-193: Found rules file is used by the plugin</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>version-rules</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>setup-provide-rules-in-jar</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rulesUri>classpath:///package/foo/bar/rules.xml</rulesUri>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>setup-provide-rules-in-jar</artifactId>
+            <version>1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-rules-via-classpath-003/verify.bsh
+++ b/src/it/it-rules-via-classpath-003/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.0.1-1.1</version>" ) < 0 )
+    {
+        System.err.println( "Version of version-rules not bumped to 3.0.1-1.1" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/setup-provide-rules-in-jar/invoker.properties
+++ b/src/it/setup-provide-rules-in-jar/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean install

--- a/src/it/setup-provide-rules-in-jar/pom.xml
+++ b/src/it/setup-provide-rules-in-jar/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>setup-provide-rules-in-jar</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+  <name>GH-193: Provide a rules file within a jar</name>
+
+
+</project>

--- a/src/it/setup-provide-rules-in-jar/src/main/resources/package/foo/bar/rules.xml
+++ b/src/it/setup-provide-rules-in-jar/src/main/resources/package/foo/bar/rules.xml
@@ -1,0 +1,5 @@
+<ruleset comparisonMethod="maven">
+  <rules>
+    <rule groupId="localhost" artifactId="version-rules" comparisonMethod="mercury"/>
+  </rules>
+</ruleset>

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -160,7 +160,9 @@ public abstract class AbstractVersionsReport
     private String serverId;
 
     /**
-     * The Wagon URI of a ruleSet file containing the rules that control how to compare version numbers.
+     * URI of a ruleSet file containing the rules that control how to compare
+     * version numbers. The URI could be either a Wagon URI or a classpath URI
+     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
      *
      * @since 1.0-alpha-3
      */

--- a/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -148,7 +148,9 @@ public abstract class AbstractVersionsUpdaterMojo
     private String serverId;
 
     /**
-     * The Wagon URI of a ruleSet file containing the rules that control how to compare version numbers.
+     * URI of a ruleSet file containing the rules that control how to compare
+     * version numbers. The URI could be either a Wagon URI or a classpath URI
+     * (e.g. <code>classpath:///package/sub/package/rules.xml</code>).
      *
      * @since 1.0-alpha-3
      */

--- a/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -66,10 +66,8 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,6 +97,8 @@ import java.util.regex.Pattern;
 public class DefaultVersionsHelper
     implements VersionsHelper
 {
+    private static final String CLASSPATH_PROTOCOL = "classpath";
+
     private static final String TYPE_EXACT = "exact";
 
     private static final String TYPE_REGEX = "regex";
@@ -222,38 +222,16 @@ public class DefaultVersionsHelper
         try
         {
             wagon.get( remoteURI, tempFile );
-            RuleXpp3Reader reader = new RuleXpp3Reader();
-            FileInputStream fis = new FileInputStream( tempFile );
+            InputStream is = new FileInputStream(tempFile );
             try
             {
-                BufferedInputStream bis = new BufferedInputStream( fis );
-                try
-                {
-                    return reader.read( bis );
-                }
-                catch ( XmlPullParserException e )
-                {
-                    final IOException ioe = new IOException();
-                    ioe.initCause( e );
-                    throw ioe;
-                }
-                finally
-                {
-                    try
-                    {
-                        bis.close();
-                    }
-                    catch ( IOException e )
-                    {
-                        // ignore
-                    }
-                }
+                return readRulesFromStream(is);
             }
             finally
             {
                 try
                 {
-                    fis.close();
+                    is.close();
                 }
                 catch ( IOException e )
                 {
@@ -267,6 +245,34 @@ public class DefaultVersionsHelper
             {
                 // maybe we can delete this later
                 tempFile.deleteOnExit();
+            }
+        }
+    }
+
+    private static RuleSet readRulesFromStream(InputStream stream)
+        throws IOException {
+        RuleXpp3Reader reader = new RuleXpp3Reader();
+        BufferedInputStream bis = new BufferedInputStream( stream );
+
+        try
+        {
+            return reader.read( bis );
+        }
+        catch ( XmlPullParserException e )
+        {
+            final IOException ioe = new IOException();
+            ioe.initCause( e );
+            throw ioe;
+        }
+        finally
+        {
+            try
+            {
+                bis.close();
+            }
+            catch ( IOException e )
+            {
+                // ignore
             }
         }
     }
@@ -285,86 +291,118 @@ public class DefaultVersionsHelper
 
     private static RuleSet loadRuleSet( String serverId, Settings settings, WagonManager wagonManager, String rulesUri,
                                         Log logger )
-        throws MojoExecutionException
-    {
+        throws MojoExecutionException {
         RuleSet ruleSet = new RuleSet();
-        if ( rulesUri != null && rulesUri.trim().length() != 0 )
-        {
-            try
-            {
-                int split = rulesUri.lastIndexOf( '/' );
-                String baseUri;
-                String fileUri;
-                if ( split != -1 )
-                {
-                    baseUri = rulesUri.substring( 0, split ) + '/';
-                    fileUri = split + 1 < rulesUri.length() ? rulesUri.substring( split + 1 ) : "";
-                }
-                else
-                {
-                    baseUri = rulesUri;
-                    fileUri = "";
-                }
-                try
-                {
-                    Wagon wagon = WagonUtils.createWagon( serverId, baseUri, wagonManager, settings, logger );
-                    try
-                    {
-                        logger.debug( "Trying to load ruleset from file \"" + fileUri + "\" in " + baseUri );
-                        final RuleSet loaded = getRuleSet( wagon, fileUri );
-                        ruleSet.setRules( loaded.getRules() );
-                        ruleSet.setIgnoreVersions( loaded.getIgnoreVersions() );
-                        logger.debug( "Rule set loaded" );
-                    }
-                    finally
-                    {
-                        if ( wagon != null )
-                        {
-                            try
-                            {
-                                wagon.disconnect();
-                            }
-                            catch ( ConnectionException e )
-                            {
-                                logger.warn( "Could not disconnect wagon!", e );
-                            }
-                        }
+        boolean rulesUriGiven = isRulesUriNotBlank(rulesUri);
 
+        if (rulesUriGiven) {
+            RuleSet loadedRules;
+
+            if (isClasspathUri(rulesUri)) {
+                loadedRules = getRulesFromClasspath(rulesUri, logger);
+            } else {
+                loadedRules = getRulesViaWagon(rulesUri, logger, serverId, serverId, wagonManager,
+                                                       settings);
+            }
+
+            ruleSet.setIgnoreVersions(loadedRules.getIgnoreVersions());
+            ruleSet.setRules(loadedRules.getRules());
+        }
+
+        return ruleSet;
+    }
+
+    private static RuleSet getRulesFromClasspath(String uri, Log logger)
+        throws MojoExecutionException {
+        logger.debug("Going to load rules from \"" + uri + "\"");
+
+        String choppedUrl = uri.substring(CLASSPATH_PROTOCOL.length() + 3);
+
+        URL url = DefaultVersionsHelper.class.getResource(choppedUrl);
+
+        if (null == url) {
+            String message = "Resource \"" + uri + "\" not found in classpath.";
+
+            throw new MojoExecutionException(message);
+        }
+
+        try {
+            RuleSet rules = readRulesFromStream(url.openStream());
+            logger.debug("Loaded rules from \"" + uri + "\" successfully");
+            return rules;
+        }
+        catch (IOException e) {
+            throw new MojoExecutionException("Could not load specified rules from " + uri, e);
+        }
+    }
+
+    private static boolean isRulesUriNotBlank(String rulesUri) {
+        return rulesUri != null && rulesUri.trim().length() != 0;
+    }
+
+    private static RuleSet getRulesViaWagon(String rulesUri, Log logger, String serverId, String id,
+                                            WagonManager wagonManager, Settings settings)
+        throws MojoExecutionException {
+        RuleSet loadedRules = new RuleSet();
+
+        int split = rulesUri.lastIndexOf('/');
+        String baseUri = rulesUri;
+        String fileUri = "";
+
+        if (split != -1) {
+            baseUri = rulesUri.substring(0, split) + '/';
+            fileUri = split + 1 < rulesUri.length() ? rulesUri.substring(split + 1) : "";
+        }
+
+        try {
+            Wagon wagon = WagonUtils.createWagon(serverId, baseUri, wagonManager, settings, logger);
+            try {
+                logger.debug("Trying to load ruleset from file \"" + fileUri + "\" in " + baseUri);
+                loadedRules = getRuleSet(wagon, fileUri);
+            }
+            finally {
+                logger.debug("Rule set loaded");
+
+                if (wagon != null) {
+                    try {
+                        wagon.disconnect();
+                    }
+                    catch (ConnectionException e) {
+                        logger.warn("Could not disconnect wagon!", e);
                     }
                 }
-                catch ( TransferFailedException e )
-                {
-                    throw new MojoExecutionException( "Could not transfer rules from " + rulesUri, e );
-                }
-                catch ( AuthorizationException e )
-                {
-                    throw new MojoExecutionException( "Authorization failure trying to load rules from " + rulesUri,
-                                                      e );
-                }
-                catch ( ResourceDoesNotExistException e )
-                {
-                    throw new MojoExecutionException( "Could not load specified rules from " + rulesUri, e );
-                }
-                catch ( AuthenticationException e )
-                {
-                    throw new MojoExecutionException( "Authentication failure trying to load rules from " + rulesUri,
-                                                      e );
-                }
-                catch ( UnsupportedProtocolException e )
-                {
-                    throw new MojoExecutionException( "Unsupported protocol for " + rulesUri, e );
-                }
-                catch ( ConnectionException e )
-                {
-                    throw new MojoExecutionException( "Could not establish connection to " + rulesUri, e );
-                }
-            }
-            catch ( IOException e )
-            {
-                throw new MojoExecutionException( "Could not load specified rules from " + rulesUri, e );
             }
         }
-        return ruleSet;
+        catch (TransferFailedException e) {
+            throw new MojoExecutionException("Could not transfer rules from " + rulesUri, e);
+        }
+        catch (AuthorizationException e) {
+            throw new MojoExecutionException("Authorization failure trying to load rules from " + rulesUri, e);
+        }
+        catch (ResourceDoesNotExistException e) {
+            throw new MojoExecutionException("Could not load specified rules from " + rulesUri, e);
+        }
+        catch (AuthenticationException e) {
+            throw new MojoExecutionException("Authentication failure trying to load rules from " + rulesUri, e);
+        }
+        catch (UnsupportedProtocolException e) {
+            throw new MojoExecutionException("Unsupported protocol for " + rulesUri, e);
+        }
+        catch (ConnectionException e) {
+            throw new MojoExecutionException("Could not establish connection to " + rulesUri, e);
+        }
+        catch (IOException e) {
+            throw new MojoExecutionException("Could not load specified rules from " + rulesUri, e);
+        }
+
+        return loadedRules;
+    }
+
+    static boolean isClasspathUri(String uri) {
+        boolean startsWithProtocol = null != uri && uri.startsWith(CLASSPATH_PROTOCOL);
+        boolean hasColonNext = null != uri && uri.charAt(CLASSPATH_PROTOCOL.length()) == ':';
+
+        return startsWithProtocol && hasColonNext;
     }
 
     /**

--- a/src/site/apt/version-rules.apt.vm
+++ b/src/site/apt/version-rules.apt.vm
@@ -134,3 +134,40 @@ Version number rules
   ...
 </project>
 ---
+
+  You can provide your ruleset xml file also within a jar, if you want to distribute
+  your ruleset xml as Maven artifact. Therefore you have to declare the containing
+  jar as direct dependency of the <<versions-maven-plugin>> and to use classpath
+  as protocol.
+
+---
+<project>
+  ...
+  <build>
+    ...
+    <plugins>
+      ...
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${pluginVersion}</version>
+        <configuration>
+          ...
+          <rulesUri>classpath:///package/foo/bar/rules.xml</rulesUri>
+          ...
+        </configuration>
+        <dependencies>
+            <dependency>
+                <groupId>com.mycompany</groupId>
+                <artifactId>version-rules</artifactId>
+                <version>1.0</version>
+            </dependency>
+        </dependencies>
+      </plugin>
+      ...
+    </plugins>
+    ...
+  </build>
+  ...
+</project>
+---

--- a/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
@@ -45,6 +45,7 @@ import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.mojo.versions.Property;
 import org.codehaus.mojo.versions.ordering.VersionComparators;
+import org.hamcrest.CoreMatchers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -177,22 +178,36 @@ public class DefaultVersionsHelperTest
         assertTrue( result.isEmpty() );
     }
 
+    public void testIsClasspathUriDetectsClassPathProtocol() throws MojoExecutionException {
+        DefaultVersionsHelper helper = createHelper();
+        String uri = "classpath:/p/a/c/k/a/g/e/resource.res";
 
-    private VersionsHelper createHelper()
+        assertThat(DefaultVersionsHelper.isClasspathUri(uri), CoreMatchers.is(true));
+    }
+
+    public void testIsClasspathUriDetectsThatItIsDifferentProtocol() throws MojoExecutionException {
+        DefaultVersionsHelper helper = createHelper();
+        String uri = "http://10.10.10.10/p/a/c/k/a/g/e/resource.res";
+
+        assertThat(DefaultVersionsHelper.isClasspathUri(uri), CoreMatchers.is(false));
+    }
+
+
+    private DefaultVersionsHelper createHelper()
         throws MojoExecutionException
     {
         return createHelper( new MavenMetadataSource() );
     }
     
-    private VersionsHelper createHelper( ArtifactMetadataSource metadataSource ) throws MojoExecutionException
+    private DefaultVersionsHelper createHelper( ArtifactMetadataSource metadataSource ) throws MojoExecutionException
     {
         final String resourcePath = "/" + getClass().getPackage().getName().replace( '.', '/' ) + "/rules.xml";
         final String rulesUri = getClass().getResource( resourcePath ).toExternalForm();
-        VersionsHelper helper = createHelper( rulesUri, metadataSource );
+        DefaultVersionsHelper helper = createHelper( rulesUri, metadataSource );
         return helper;
     }
 
-    private VersionsHelper createHelper( String rulesUri, ArtifactMetadataSource metadataSource )
+    private DefaultVersionsHelper createHelper( String rulesUri, ArtifactMetadataSource metadataSource )
         throws MojoExecutionException
     {
         final DefaultWagonManager wagonManager = new DefaultWagonManager()
@@ -204,7 +219,7 @@ public class DefaultVersionsHelperTest
             }
         };
 
-        VersionsHelper helper =
+        DefaultVersionsHelper helper =
             new DefaultVersionsHelper( new DefaultArtifactFactory(), new DefaultArtifactResolver(), metadataSource, new ArrayList(),
                                        new ArrayList(),
                                        new DefaultArtifactRepository( "", "", new DefaultRepositoryLayout() ),


### PR DESCRIPTION
 o Added support for loading rules from the classpath.
 o Mentioned support for loading the rules file from the classpath in JavaDoc.
 o Update the documentation with an example how to load a rules files from the classpath.