### PR TITLE
Add ability to update plugins

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -52,6 +52,12 @@
 
  * [Fixed Issue 215][issue-215]
 
+ * [Fixed Issue 8][issue-8]
+
+   _Thanks to [Adam Voss](https://github.com/adamvoss)_
+
+   Many of the goals can now update plugins if you set the `processPlugins` property.
+
 ## 2.5
 
 
@@ -139,6 +145,7 @@
    
 
 
+[issue-8]: https://github.com/mojohaus/versions-maven-plugin/issues/8
 [issue-34]: https://github.com/mojohaus/versions-maven-plugin/issues/34
 [issue-37]: https://github.com/mojohaus/versions-maven-plugin/issues/37
 [issue-46]: https://github.com/mojohaus/versions-maven-plugin/issues/46

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -22,11 +22,19 @@
     is not compatible with project minimum version, not really a proposed
     upgrade
 
- * [Fixed Issue 237][issue-237]
+ * [Fixed Issue 237][issue-237] and [Fixed Issue 288][issue-288]
 
-   Thanks to Julian Di Leonardo <DiJu519@users.noreply.github.com>
+   Thanks to Julian Di Leonardo <DiJu519@users.noreply.github.com> and [Adam Voss](https://github.com/adamvoss)
 
-   Adding parent processing to UseLatestVersion/UseLatestSnapshot/UseLatestRelease
+   Added parent processing to:
+     - UseLatestVersion
+     - UseLatestSnapshot
+     - UseLatestRelease
+     - ForceReleases
+     - UseDepVersion
+     - UseNextReleases
+     - UseNextSnapshots
+     - UseNextVersions
 
  * [Fixed Issue 190][issue-190]
 
@@ -153,6 +161,7 @@
 [issue-198]: https://github.com/mojohaus/versions-maven-plugin/issues/198
 [issue-237]: https://github.com/mojohaus/versions-maven-plugin/issues/237
 [issue-256]: https://github.com/mojohaus/versions-maven-plugin/issues/256
+[issue-288]: https://github.com/mojohaus/versions-maven-plugin/issues/288
 
 [pull-189]: https://github.com/mojohaus/versions-maven-plugin/pull/189
 [pull-252]: https://github.com/mojohaus/versions-maven-plugin/pull/252

--- a/src/it/it-use-latest-releases-008/invoker.properties
+++ b/src/it/it-use-latest-releases-008/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases

--- a/src/it/it-use-latest-releases-008/pom.xml
+++ b/src/it/it-use-latest-releases-008/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-008</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Updates a plugin when processPlugins is true</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <processPlugins>true</processPlugins>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-use-latest-releases-008/verify.bsh
+++ b/src/it/it-use-latest-releases-008/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>3.1</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-maven-plugin not bumped to 3.1" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-latest-releases-009/invoker.properties
+++ b/src/it/it-use-latest-releases-009/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-latest-releases

--- a/src/it/it-use-latest-releases-009/pom.xml
+++ b/src/it/it-use-latest-releases-009/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-008</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Does not update plugins when processPlugins is false (default)</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+
+      <plugin>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-maven-plugin</artifactId>
+          <version>1.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+</build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
+</project>

--- a/src/it/it-use-latest-releases-009/verify.bsh
+++ b/src/it/it-use-latest-releases-009/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>1.0</version>" ) < 0 || buf.indexOf( "<version>3.1</version>" ) > 0 )
+    {
+        System.err.println( "Version of dummy-maven-plugin was changed.  Should have stayed at 1.0." );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-releases-005/invoker.properties
+++ b/src/it/it-use-next-releases-005/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-releases

--- a/src/it/it-use-next-releases-005/pom.xml
+++ b/src/it/it-use-next-releases-005/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-next-releases-005</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a parent dependency</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-impl</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <processParent>true</processParent>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-use-next-releases-005/verify.bsh
+++ b/src/it/it-use-next-releases-005/verify.bsh
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.util.regex.*;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+
+    BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( file ), "UTF-8" ) );
+    StringBuilder buf = new StringBuilder();
+    String line = in.readLine();
+    while ( line != null )
+    {
+        buf.append( line );
+        buf.append( " " );
+        line = in.readLine();
+    }
+
+    Pattern p = Pattern.compile( "\\Q<parent>\\E.*\\Q<version>\\E\\s*2\\.0\\s*\\Q</version>\\E.*\\Q</parent>\\E" );
+    Matcher m = p.matcher( buf.toString() );
+    if ( !m.find() )
+    {
+        System.out.println( "Did not update parent to version 2.0" );
+        return false;
+    }
+    System.out.println( m.group( 0 ) );
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-releases-006/invoker.properties
+++ b/src/it/it-use-next-releases-006/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-releases

--- a/src/it/it-use-next-releases-006/pom.xml
+++ b/src/it/it-use-next-releases-006/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-008</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Updates a reporting plugin when processPlugins is true</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <processPlugins>true</processPlugins>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
+</project>

--- a/src/it/it-use-next-releases-006/verify.bsh
+++ b/src/it/it-use-next-releases-006/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>2.0</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-maven-plugin not bumped to 2.0" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/it-use-next-versions-004/invoker.properties
+++ b/src/it/it-use-next-versions-004/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:use-next-versions

--- a/src/it/it-use-next-versions-004/pom.xml
+++ b/src/it/it-use-next-versions-004/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-latest-releases-008</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Updates a plugin in pluginManagement when processPlugins is true</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <processPlugins>true</processPlugins>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-maven-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+  </build>
+
+</project>

--- a/src/it/it-use-next-versions-004/verify.bsh
+++ b/src/it/it-use-next-versions-004/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<version>2.1</version>" ) < 0 )
+    {
+        System.err.println( "Version of dummy-maven-plugin not bumped to 2.1" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/codehaus/mojo/versions/ArtifactIdentifier.java
+++ b/src/main/java/org/codehaus/mojo/versions/ArtifactIdentifier.java
@@ -1,0 +1,28 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+
+/**
+ * Abstraction identifying an artifact
+ *
+ * This allows the same code to handle either plugins or dependencies
+ */
+interface ArtifactIdentifier
+{
+    String getGroupId();
+
+    String getArtifactId();
+
+    String getVersion();
+
+    /**
+     * Gets the Artifact that represented by this instance.
+     */
+    Artifact getArtifact( MavenProject project, VersionsHelper versionsHelper ) throws MojoExecutionException;
+
+    @Override
+    String toString();
+}

--- a/src/main/java/org/codehaus/mojo/versions/DependencyArtifactIdentifier.java
+++ b/src/main/java/org/codehaus/mojo/versions/DependencyArtifactIdentifier.java
@@ -1,0 +1,137 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+
+final class DependencyArtifactIdentifier implements ArtifactIdentifier
+{
+    private final Dependency dependency;
+
+    DependencyArtifactIdentifier( Dependency dependency )
+    {
+        this.dependency = dependency;
+    }
+
+    /**
+     * Get the project group that produced the dependency, e.g.
+     * <code>org.apache.maven</code>.
+     *
+     * @return String
+     */
+    @Override
+    public final String getGroupId()
+    {
+        return dependency.getGroupId();
+    }
+
+
+    /**
+     * Get the unique id for an artifact produced by the project
+     * group, e.g.
+     * <code>maven-artifact</code>.
+     *
+     * @return String
+     */
+    @Override
+    public final String getArtifactId()
+    {
+        return dependency.getArtifactId();
+    }
+
+    /**
+     * Get the version of the dependency, e.g. <code>3.2.1</code>.
+     * In Maven 2, this can also be
+     * specified as a range of versions.
+     *
+     * @return String
+     */
+    @Override
+    public final String getVersion()
+    {
+        return dependency.getVersion();
+    }
+
+    @Override
+    public Artifact getArtifact( MavenProject project, VersionsHelper versionsHelper ) throws MojoExecutionException
+    {
+        Artifact artifact = findArtifact( dependency, project.getDependencyArtifacts() );
+        if ( artifact == null )
+        {
+            try
+            {
+                return versionsHelper.createDependencyArtifact( dependency );
+            }
+            catch ( InvalidVersionSpecificationException e )
+            {
+                throw new MojoExecutionException( e.getMessage(), e );
+            }
+        }
+        return artifact;
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder buf = new StringBuilder();
+        buf.append( getGroupId() );
+        buf.append( ':' );
+        buf.append( getArtifactId() );
+        if ( this.dependency.getType() != null && !dependency.getType().isEmpty() )
+        {
+            buf.append( ':' );
+            buf.append( dependency.getType() );
+        }
+        else
+        {
+            buf.append( ":jar" );
+        }
+        if ( dependency.getClassifier() != null && !dependency.getClassifier().isEmpty() )
+        {
+            buf.append( ':' );
+            buf.append( dependency.getClassifier() );
+        }
+        if ( this.getVersion() != null && !dependency.getVersion().isEmpty() )
+        {
+            buf.append( ':' );
+            buf.append( getVersion() );
+        }
+        return buf.toString();
+    }
+
+    static Artifact findArtifact( Dependency dependency, Iterable<Artifact> artifacts )
+    {
+        if ( artifacts == null )
+        {
+            return null;
+        }
+
+        for ( final Artifact artifact : artifacts )
+        {
+            if ( compare( artifact, dependency ) )
+            {
+                return artifact;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Compare and artifact to a dependency. Returns true only if the groupId, artifactId, type, and classifier are all
+     * equal.
+     *
+     * @return true if artifact and dep refer to the same artifact
+     */
+    private static boolean compare( Artifact artifact, Dependency dep )
+    {
+        return StringUtils.equals( artifact.getGroupId(), dep.getGroupId() )
+                && StringUtils.equals( artifact.getArtifactId(), dep.getArtifactId() )
+                && StringUtils.equals( artifact.getType(), dep.getType() )
+                && StringUtils.equals( artifact.getClassifier(), dep.getClassifier() );
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/ParentUpdatingDependencyUpdateMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/ParentUpdatingDependencyUpdateMojo.java
@@ -1,0 +1,78 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public abstract class ParentUpdatingDependencyUpdateMojo extends AbstractVersionsDependencyUpdaterMojo
+{
+    /**
+     * @param pom the pom to update.
+     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
+     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
+     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
+     * @see AbstractVersionsUpdaterMojo#update(org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader)
+     */
+    protected void update( ModifiedPomXMLEventReader pom )
+       throws MojoExecutionException, MojoFailureException, XMLStreamException
+    {
+        try
+        {
+            if ( getProject().getDependencyManagement() != null && isProcessingDependencyManagement() )
+            {
+                setVersions( pom, getProject().getDependencyManagement().getDependencies() );
+            }
+            if ( getProject().getDependencies() != null && isProcessingDependencies() )
+            {
+                setVersions( pom, getProject().getDependencies() );
+            }
+            if ( getProject().getParent() != null && isProcessingParent() )
+            {
+                final Dependency dependency = new Dependency();
+                dependency.setArtifactId(getProject().getParent().getArtifactId());
+                dependency.setGroupId(getProject().getParent().getGroupId());
+                dependency.setVersion(getProject().getParent().getVersion());
+                dependency.setType("pom");
+                setVersions( pom, Collections.singleton(dependency));
+            }
+        }
+        catch ( ArtifactMetadataRetrievalException e )
+        {
+            throw new MojoExecutionException( e.getMessage(), e );
+        }
+    }
+
+    protected abstract void setVersions(ModifiedPomXMLEventReader pom, Collection<Dependency> dependencies)
+            throws ArtifactMetadataRetrievalException, XMLStreamException, MojoExecutionException;
+
+    protected void setVersion(ModifiedPomXMLEventReader pom, Dependency dep, String version, Artifact artifact, ArtifactVersion artifactVersion) throws XMLStreamException
+    {
+        final String newVersion = artifactVersion.toString();
+        if(getProject().getParent() != null){
+            if(artifact.getId().equals(getProject().getParentArtifact().getId()) && isProcessingParent())
+            {
+                if ( PomHelper.setProjectParentVersion( pom, newVersion.toString() ) )
+                {
+                    getLog().debug( "Made parent change from " + version + " to " + newVersion.toString() );
+                }
+            }
+        }
+
+        if ( PomHelper.setDependencyVersion( pom, dep.getGroupId(), dep.getArtifactId(), version,
+                                             newVersion, getProject().getModel() ) )
+        {
+            getLog().info( "Changed " + toString( dep ) + " to version " + newVersion );
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/PluginArtifactIdentifier.java
+++ b/src/main/java/org/codehaus/mojo/versions/PluginArtifactIdentifier.java
@@ -1,0 +1,77 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+
+final class PluginArtifactIdentifier implements ArtifactIdentifier
+{
+    private final Plugin plugin;
+
+    PluginArtifactIdentifier( Plugin plugin )
+    {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getGroupId()
+    {
+        return plugin.getGroupId();
+    }
+
+    @Override
+    public String getArtifactId()
+    {
+        return plugin.getArtifactId();
+    }
+
+    @Override
+    public String getVersion()
+    {
+        return plugin.getVersion();
+    }
+
+    @Override
+    public Artifact getArtifact( MavenProject project, VersionsHelper versionsHelper )
+    {
+        final Artifact artifact = findArtifact( plugin, project.getPluginArtifacts() );
+        if ( artifact == null )
+        {
+            return versionsHelper.createPluginArtifact( plugin.getGroupId(), plugin.getArtifactId(), VersionRange.createFromVersion( plugin.getVersion() ) );
+        }
+        return artifact;
+    }
+
+    @Override
+    public String toString()
+    {
+        return plugin.getGroupId() + ':' + plugin.getArtifactId() + ':' + plugin.getVersion();
+    }
+
+    private static Artifact findArtifact( Plugin dependency, Iterable<Artifact> artifacts )
+    {
+        if ( artifacts == null )
+        {
+            return null;
+        }
+
+        for ( final Artifact artifact : artifacts )
+        {
+            if ( compare( artifact, dependency ) )
+            {
+                return artifact;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean compare( Artifact artifact, Plugin dep )
+    {
+        return StringUtils.equals( artifact.getGroupId(), dep.getGroupId() )
+                && StringUtils.equals( artifact.getArtifactId(), dep.getArtifactId() );
+    }
+}

--- a/src/main/java/org/codehaus/mojo/versions/ReportPluginArtifactIdentifier.java
+++ b/src/main/java/org/codehaus/mojo/versions/ReportPluginArtifactIdentifier.java
@@ -1,0 +1,78 @@
+package org.codehaus.mojo.versions;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.ReportPlugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+
+final class ReportPluginArtifactIdentifier implements ArtifactIdentifier
+{
+    private final ReportPlugin plugin;
+
+    ReportPluginArtifactIdentifier( ReportPlugin plugin )
+    {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getGroupId()
+    {
+        return plugin.getGroupId();
+    }
+
+    @Override
+    public String getArtifactId()
+    {
+        return plugin.getArtifactId();
+    }
+
+    @Override
+    public String getVersion()
+    {
+        return plugin.getVersion();
+    }
+
+    @Override
+    public Artifact getArtifact( MavenProject project, VersionsHelper versionsHelper )
+    {
+        final Artifact artifact = findArtifact( plugin, project.getReportArtifacts() );
+        if ( artifact == null )
+        {
+            return versionsHelper.createPluginArtifact(
+                    plugin.getGroupId(), plugin.getArtifactId(), VersionRange.createFromVersion( plugin.getVersion() ) );
+        }
+        return artifact;
+    }
+
+    @Override
+    public String toString()
+    {
+        return plugin.getGroupId() + ':' + plugin.getArtifactId() + ':' + plugin.getVersion();
+    }
+
+    private static Artifact findArtifact( ReportPlugin dependency, Iterable<Artifact> artifacts )
+    {
+        if ( artifacts == null )
+        {
+            return null;
+        }
+
+        for ( final Artifact artifact : artifacts )
+        {
+            if ( compare( artifact, dependency ) )
+            {
+                return artifact;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean compare( Artifact artifact, ReportPlugin dep )
+    {
+        return StringUtils.equals( artifact.getGroupId(), dep.getGroupId() )
+                && StringUtils.equals( artifact.getArtifactId(), dep.getArtifactId() );
+    }
+}


### PR DESCRIPTION
The property `processPlugins` has been added (default: false making the change backwards compatible) which enables updating of plugins (plugins, reporting plugins, and plugin management) for the following Mojos:

   - UseLatestVersion
   - UseLatestSnapshot
   - UseLatestRelease
   - ForceReleases
   - UseDepVersion
   - UseNextReleases
   - UseNextSnapshots
   - UseNextVersions

This depends on #289 which has not been merged, making this diff harder at the moment, but I wanted to get this out there now that I had it.  I didn't need to add much new logic to support this, just refactor the existing code to be able to utilize existing functionality.

Fixes #8 