### PR TITLE
Make Max Dependency enforcer rule as main page of enforcer module

### DIFF
--- a/versions-enforcer/src/site/markdown/index.md.vm
+++ b/versions-enforcer/src/site/markdown/index.md.vm
@@ -1,5 +1,5 @@
 
-title: Introduction
+title: Max Dependency Updates
 author: Andrzej Jarmoniuk
 date: 2022-10-27
 

--- a/versions-enforcer/src/site/site.xml
+++ b/versions-enforcer/src/site/site.xml
@@ -6,10 +6,6 @@
       <item name="Maven Enforcer Rules" href="index.html"/>
     </menu>
 
-    <menu name="Rules Details">
-      <item name="Max Dependency Updates" href="max-dependency-updates.html"/>
-    </menu>
-
     <menu ref="parent"/>
   </body>
 </project>

--- a/versions-maven-plugin/src/site/markdown/index.md
+++ b/versions-maven-plugin/src/site/markdown/index.md
@@ -96,7 +96,7 @@ The Versions Plugin has the following reporting goals.
 ## Enforcer rules overview
 
 The Versions Plugin currently provides one Maven Enforcer Plugin rule:
-* [maxDependencyUpdates](../versions-enforcer/max-dependency-updates.html) allows the user to specify a maximum number of updates which,
+* [maxDependencyUpdates](../versions-enforcer/index.html) allows the user to specify a maximum number of updates which,
   if exceeded, will trigger the enforcer plugin to fail.
 
 ## Usage


### PR DESCRIPTION
We have only one enforcer rule so can be as main page of module