### PR TITLE
Resolves #855: Set should evaluate expressions

### DIFF
--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
@@ -158,4 +158,49 @@ public class SetMojoTest extends AbstractMojoTestCase {
                 String.join("", Files.readAllLines(tempDir.resolve("pom.xml"))),
                 not(containsString("<version>bar</version>")));
     }
+
+    private void testSetParameterValue(String filename) throws Exception {
+        Files.copy(
+                Paths.get("src/test/resources/org/codehaus/mojo/set/issue-855/").resolve(filename),
+                tempDir.resolve("pom.xml"));
+        SetMojo mojo = (SetMojo) mojoRule.lookupConfiguredMojo(tempDir.toFile(), "set");
+        mojo.execute();
+        assertThat(
+                String.join("", Files.readAllLines(tempDir.resolve("pom.xml"))),
+                containsString("<version>testing</version>"));
+    }
+
+    @Test
+    public void testSetParameterValueSimple() throws Exception {
+        testSetParameterValue("pom-simple.xml");
+    }
+
+    @Test
+    public void testSetParameterValueBuildNumber() throws Exception {
+        testSetParameterValue("pom-build-number.xml");
+    }
+
+    @Test
+    public void testSetParameterValueUndefined() throws Exception {
+        testSetParameterValue("pom-undefined.xml");
+    }
+
+    @Test
+    public void testSetParameterValueMultipleProps() throws Exception {
+        testSetParameterValue("pom-multiple-props.xml");
+    }
+
+    @Test
+    public void testParentWithProperty() throws Exception {
+        TestUtils.copyDir(
+                Paths.get("src/test/resources/org/codehaus/mojo/set/issue-855/parent-with-property"), tempDir);
+        SetMojo mojo = (SetMojo) mojoRule.lookupConfiguredMojo(tempDir.toFile(), "set");
+        mojo.execute();
+        assertThat(
+                String.join("", Files.readAllLines(tempDir.resolve("pom.xml"))),
+                containsString("<version>testing</version>"));
+        assertThat(
+                String.join("", Files.readAllLines(tempDir.resolve("child/pom.xml"))),
+                containsString("<version>testing</version>"));
+    }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/parent-with-property/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/parent-with-property/child/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.example</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>test-child</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/parent-with-property/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/parent-with-property/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <groupId>org.example</groupId>
+  <artifactId>test-parent</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+
+  <modules>
+    <module>child</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <goals>
+          <goal>set</goal>
+        </goals>
+        <configuration>
+          <newVersion>testing</newVersion>
+          <generateBackupPoms>false</generateBackupPoms>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-build-number.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-build-number.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>org.example</groupId>
+    <artifactId>test-versions</artifactId>
+    <version>${revision}</version>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <revision>1.0.0-${buildNumber}-SNAPSHOT</revision>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>set</goal>
+                </goals>
+                <configuration>
+                    <newVersion>testing</newVersion>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-multiple-props.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-multiple-props.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>org.example</groupId>
+    <artifactId>test-versions</artifactId>
+    <version>${revision}</version>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <revision>1.0.0-${buildNumber}-SNAPSHOT</revision>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>set</goal>
+                </goals>
+                <configuration>
+                    <newVersion>testing</newVersion>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-simple.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-simple.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>org.example</groupId>
+    <artifactId>test-versions</artifactId>
+    <version>${revision}</version>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <revision>1.3</revision>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>set</goal>
+                </goals>
+                <configuration>
+                    <newVersion>testing</newVersion>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-undefined.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set/issue-855/pom-undefined.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>org.example</groupId>
+    <artifactId>test-versions</artifactId>
+    <version>${revision}</version>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <revision>1.0.0-${buildNumber}-SNAPSHOT</revision>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <goals>
+                    <goal>set</goal>
+                </goals>
+                <configuration>
+                    <newVersion>testing</newVersion>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixing a regression after #799 

The premise of that PR was that the mojo was updating every file if it **did not** find any match anywhere. This made the mojo update files where e.g. the version was specified as a parameter. 

The fix does it differently -- by resolving parameters and checking if they match the artifact coordinates.