### PR TITLE
#858 Fix child module resolution for multi-level projects

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -1356,7 +1356,7 @@ public class PomHelper {
 
         File baseDir = model.getPomFile().getParentFile();
 
-        getAllChildModules(model, logger).parallelStream()
+        getAllChildModules(model, logger).stream()
                 .map(moduleName -> new File(baseDir, moduleName))
                 .map(file -> file.isFile() ? file : new File(file, "pom.xml"))
                 .filter(File::exists)

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -367,7 +367,7 @@ public class SetMojo extends AbstractVersionsUpdaterMojo {
             }
 
             if ("always".equals(updateBuildOutputTimestampPolicy)) {
-                reactor.values().parallelStream()
+                reactor.values().stream()
                         .map(m -> PomHelper.getModelEntry(reactor, PomHelper.getGroupId(m), PomHelper.getArtifactId(m)))
                         .filter(Objects::nonNull)
                         .map(Map.Entry::getValue)


### PR DESCRIPTION
Child modules were processed in a parallel stream which added elements to an unsynchonized LinkedHashMap.

This may resulted an incomplete set of child modules.