### PR TITLE
Removes parallelStream use with non-thread safe collectors

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -194,7 +194,7 @@ public class DefaultVersionsHelper implements VersionsHelper {
                                                             .getRemoteProjectRepositories(),
                                             "lookupArtifactVersions"))
                             .getVersions()
-                            .parallelStream()
+                            .stream()
                             .filter(v -> ignoredVersions.stream().noneMatch(i -> {
                                 if (TYPE_REGEX.equals(i.getType())
                                         && Pattern.compile(i.getVersion())

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -61,7 +61,7 @@ public class MavenProjectUtils {
      * or an empty set if none have been retrieveddependencies or an empty set if none have been retrieved
      */
     public static Set<Dependency> extractDependenciesFromPlugins(MavenProject project) {
-        return project.getBuildPlugins().parallelStream()
+        return project.getBuildPlugins().stream()
                 .filter(plugin -> plugin.getDependencies() != null)
                 .flatMap(plugin -> plugin.getDependencies().stream())
                 .collect(() -> new TreeSet<>(DependencyComparator.INSTANCE), Set::add, Set::addAll);

--- a/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
+++ b/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
@@ -268,7 +268,7 @@ public class MaxDependencyUpdates implements EnforcerRule2 {
             return new DefaultVersionsHelper.Builder()
                     .withRepositorySystem(ruleHelper.getComponent(RepositorySystem.class))
                     .withAetherRepositorySystem(ruleHelper.getComponent(org.eclipse.aether.RepositorySystem.class))
-                    .withWagonMap(ruleHelper.getComponentMap(Wagon.class.getName()).entrySet().parallelStream()
+                    .withWagonMap(ruleHelper.getComponentMap(Wagon.class.getName()).entrySet().stream()
                             .filter(e -> e.getValue() instanceof Wagon)
                             .collect(HashMap::new, (m, e) -> m.put(e.getKey(), (Wagon) e.getValue()), HashMap::putAll))
                     .withServerId(serverId)
@@ -349,7 +349,7 @@ public class MaxDependencyUpdates implements EnforcerRule2 {
                     ? of(SUBINCREMENTAL)
                     : ignoreIncrementalUpdates ? of(INCREMENTAL) : ignoreMinorUpdates ? of(MINOR) : empty();
             List<ArtifactVersions> upgradable =
-                    versionsHelper.lookupDependenciesUpdates(dependencies, false).values().parallelStream()
+                    versionsHelper.lookupDependenciesUpdates(dependencies, false).values().stream()
                             .filter(v -> v.getVersions(v.restrictionForIgnoreScope(ignoredSegment), true).length > 0)
                             .collect(Collectors.toList());
             if (upgradable.size() > maxUpdates) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -429,8 +429,8 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         getHelper()
                                 .lookupDependenciesUpdates(
                                         filterDependencies(
-                                                getProject().getDependencies().parallelStream()
-                                                        .filter(dep -> finalDependencyManagement.parallelStream()
+                                                getProject().getDependencies().stream()
+                                                        .filter(dep -> finalDependencyManagement.stream()
                                                                 .noneMatch(depMan -> dependenciesMatch(dep, depMan)))
                                                         .collect(
                                                                 () -> new TreeSet<>(DependencyComparator.INSTANCE),

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -856,7 +856,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
      * @since 1.0-alpha-1
      */
     private Map<String, Plugin> getLifecyclePlugins(MavenProject project) throws MojoExecutionException {
-        return getBoundPlugins(project).parallelStream()
+        return getBoundPlugins(project).stream()
                 .filter(Objects::nonNull)
                 .filter(p -> p.getKey() != null)
                 .collect(HashMap<String, Plugin>::new, (m, p) -> m.put(p.getKey(), p), Map::putAll);
@@ -874,7 +874,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     private Set<Plugin> getBoundPlugins(MavenProject project) {
         // we need to provide a copy with the version blanked out so that inferring from super-pom
         // works as for 2.x as 3.x fills in the version on us!
-        return lifecycleExecutor.getPluginsBoundByDefaultToAllLifecycles(project.getPackaging()).parallelStream()
+        return lifecycleExecutor.getPluginsBoundByDefaultToAllLifecycles(project.getPackaging()).stream()
                 .map(p -> new Plugin() {
                     {
                         setGroupId(p.getGroupId());


### PR DESCRIPTION
Relates to #855, reviewed and removed unsafe parallelStream usage where the terminator was not thread safe.