### PR TITLE
Resolves #474: Using raw model for dependencies in UseDepVersion

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -94,17 +95,17 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
         }
 
         try {
+            Model rawModel = PomHelper.getRawModel(getProject());
             if (isProcessingDependencyManagement()) {
-                DependencyManagement dependencyManagement =
-                        PomHelper.getRawModel(getProject()).getDependencyManagement();
+                DependencyManagement dependencyManagement = rawModel.getDependencyManagement();
                 if (dependencyManagement != null) {
                     useDepVersion(
                             pom, dependencyManagement.getDependencies(), ChangeRecord.ChangeKind.DEPENDENCY_MANAGEMENT);
                 }
             }
 
-            if (getProject().getDependencies() != null && isProcessingDependencies()) {
-                useDepVersion(pom, getProject().getDependencies(), ChangeRecord.ChangeKind.DEPENDENCY);
+            if (rawModel.getDependencies() != null && isProcessingDependencies()) {
+                useDepVersion(pom, rawModel.getDependencies(), ChangeRecord.ChangeKind.DEPENDENCY);
             }
 
             if (getProject().getParent() != null && isProcessingParent()) {
@@ -121,11 +122,6 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
         for (Dependency dep : dependencies) {
             if (isExcludeReactor() && isProducedByReactor(dep)) {
                 getLog().info("Ignoring reactor dependency: " + toString(dep));
-                continue;
-            }
-
-            if (isHandledByProperty(dep)) {
-                getLog().debug("Ignoring dependency with property as version: " + toString(dep));
                 continue;
             }
 

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseDepVersionMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseDepVersionMojoTest.java
@@ -19,13 +19,26 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.MojoRule;
+import org.codehaus.mojo.versions.change.DefaultVersionChange;
+import org.codehaus.mojo.versions.utils.TestChangeRecorder;
+import org.codehaus.mojo.versions.utils.TestUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySystem;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockRepositorySystem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * Basic tests for {@linkplain UseDepVersionMojo}.
@@ -36,16 +49,51 @@ public class UseDepVersionMojoTest extends AbstractMojoTestCase {
     @Rule
     public MojoRule mojoRule = new MojoRule(this);
 
+    private Path tempDir;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = TestUtils.createTempDir("use-dep-version");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            TestUtils.tearDownTempDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
     @Test
     public void testIssue673() throws Exception {
-        UseDepVersionMojo mojo = (UseDepVersionMojo) mojoRule.lookupConfiguredMojo(
-                new File("target/test-classes/org/codehaus/mojo/use-dep-version/issue-637"), "use-dep-version");
-        setVariableValueToObject(mojo, "processDependencies", true);
-        setVariableValueToObject(mojo, "processDependencyManagement", true);
-        setVariableValueToObject(mojo, "excludeReactor", true);
+        TestUtils.copyDir(Paths.get("src/test/resources/org/codehaus/mojo/use-dep-version/issue-637"), tempDir);
+        UseDepVersionMojo mojo = (UseDepVersionMojo) mojoRule.lookupConfiguredMojo(tempDir.toFile(), "use-dep-version");
         setVariableValueToObject(mojo, "serverId", "serverId");
         setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(mojo.getProject()));
 
         mojo.execute();
+    }
+
+    @Test
+    public void testParameters() throws Exception {
+        TestUtils.copyDir(Paths.get("src/test/resources/org/codehaus/mojo/use-dep-version/issue-474"), tempDir);
+        TestChangeRecorder changeRecorder = new TestChangeRecorder();
+        UseDepVersionMojo mojo = (UseDepVersionMojo) mojoRule.lookupConfiguredMojo(tempDir.toFile(), "use-dep-version");
+        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(mojo.getProject()));
+        setVariableValueToObject(mojo, "repositorySystem", mockRepositorySystem());
+        setVariableValueToObject(mojo, "aetherRepositorySystem", mockAetherRepositorySystem());
+        setVariableValueToObject(mojo, "changeRecorders", changeRecorder.asTestMap());
+
+        mojo.execute();
+
+        assertThat(
+                changeRecorder.getChanges(),
+                hasItem(new DefaultVersionChange("default-group", "artifactA", "${revision}", "2.0.0")));
+
+        assertThat(
+                String.join("", Files.readAllLines(tempDir.resolve(Paths.get("pom.xml")))),
+                containsString("<version>2.0.0</version>"));
     }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/issue-474/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/issue-474/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>default-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <serverId>serverId</serverId>
+                    <includesList>default-group</includesList>
+                    <depVersion>2.0.0</depVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
UseDepVersion mojo did not allow changing the dependency for dependencies which used a property.

For a reason: this basically does not work with the interpolated model: *PomHelper.setDependencyVersion* works by comparing the text of the POM file with the dependency coordinates and will replace the dependency when a string comparison match is found. 

If we work on the interpolated model, the properties will be resolved, thus the dependency version will also be set and will no longer use a property. `UseDepVersion` **will** call *PomHelper.setDependencyVersion*, but it will not be able to retrieve the dependency to be changed, since the POM file still contains the unresolved property.

To mitigate that, here we are using the unresolved, raw model to do that. It does the job.

What's more, I think that the same problem exists everywhere else. I'm not changing it everywhere else, because I think we need to give it a thought. 

Anwyay, please review and merge @slawekjaranowski 