### PR TITLE
Add a simple cache for ComparableVersions

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
@@ -56,7 +56,7 @@ public class BoundArtifactVersion extends DefaultArtifactVersion {
             return -1;
         }
 
-        return comparator.compareTo(new ComparableVersion(other.toString()));
+        return comparator.compareTo(ComparableVersion.of(other.toString()));
     }
 
     @Override

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/ComparableVersion.java
@@ -26,8 +26,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Generic implementation of version comparison.
@@ -37,6 +39,8 @@ import java.util.Stack;
  * Note: The implementation of the maven core should be used.
  */
 public class ComparableVersion implements Comparable<ComparableVersion> {
+    private static final Map<String, ComparableVersion> CACHE = new ConcurrentHashMap<>();
+
     private String value;
 
     private String canonical;
@@ -283,7 +287,17 @@ public class ComparableVersion implements Comparable<ComparableVersion> {
         }
     }
 
-    public ComparableVersion(String version) {
+    /**
+     * Get a ComparableVersion representing the version in a string.
+     */
+    public static ComparableVersion of(String version) {
+        return CACHE.computeIfAbsent(version, ComparableVersion::new);
+    }
+
+    /**
+     * Create a ComparableVersion from a string. Try to avoid using this and instead use the cache by calling {@link #of(String)}
+     */
+    protected ComparableVersion(String version) {
         parseVersion(version);
     }
 

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
@@ -39,7 +39,7 @@ public class MavenVersionComparator extends AbstractVersionComparator {
         if (o1 instanceof BoundArtifactVersion) {
             return o1.compareTo(o2);
         }
-        return new ComparableVersion(o1.toString()).compareTo(new ComparableVersion(o2.toString()));
+        return ComparableVersion.of(o1.toString()).compareTo(ComparableVersion.of(o2.toString()));
     }
 
     /**

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MercuryVersionComparator.java
@@ -40,7 +40,7 @@ public class MercuryVersionComparator extends AbstractVersionComparator {
      * {@inheritDoc}
      */
     public int compare(ArtifactVersion o1, ArtifactVersion o2) {
-        return new ComparableVersion(o1.toString()).compareTo(new ComparableVersion(o2.toString()));
+        return ComparableVersion.of(o1.toString()).compareTo(ComparableVersion.of(o2.toString()));
     }
 
     protected int innerGetSegmentCount(ArtifactVersion v) {


### PR DESCRIPTION
This is a simple fix for #869.

This can improve performance in pathetic corner cases by up to 50%. From some example executions (something similar as the pathetic case in #869):

Before:
```
[INFO] Total time:  01:51 min
```

After:
```
[INFO] Total time:  43.714 s
```

In this first implementation, the cache is unbounded. In all my tests it never grew over ~1500 entries, but it might keep some memory active in pathetic cases...

PS: I used a ConcurrentHashMap, because I don't know how parallel (if at all?) Maven can run this code...