### PR TITLE
Resolves #872: Make allowSnapshots an explicit argument in lookupDependencyUpdates and in reports

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
@@ -91,7 +91,6 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
         versionComparator = other.versionComparator;
         versions = other.versions;
         setCurrentVersion(other.getCurrentVersion());
-        setIncludeSnapshots(other.isIncludeSnapshots());
     }
 
     @SuppressWarnings("checkstyle:InnerAssignment")
@@ -122,7 +121,7 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
 
         return new EqualsBuilder()
                 .append(getArtifact(), that.getArtifact())
-                .append(getVersions(), that.getVersions())
+                .append(getVersions(true), that.getVersions(true))
                 .append(getVersionComparator(), that.getVersionComparator())
                 .isEquals();
     }
@@ -131,7 +130,7 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
                 .append(getArtifact())
-                .append(getVersions())
+                .append(getVersions(true))
                 .append(getVersionComparator())
                 .toHashCode();
     }
@@ -216,6 +215,24 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
                 : versions.stream()
                         .filter(v -> !ArtifactUtils.isSnapshot(v.toString()))
                         .toArray(ArtifactVersion[]::new);
+    }
+
+    /**
+     * Says whether the versions present in the {@link ArtifactVersions} collection are empty.
+     * If {@code includeSnapshots} is {@code true}, snapshots will not counted, which means that
+     * the method will only count release versions.
+     *
+     * @param includeSnapshots {@code includeSnapshots} is {@code true}, snapshots will not counted, which means that
+     *      * the method will only count release versions.
+     * @return if {@code includeSnapshots} is {@code true}, returns {@code true} if there are no versions.
+     * if {@code includeSnapshots} is {@code false}, returns {@code true} if there are no releases.
+     */
+    public boolean isEmpty(boolean includeSnapshots) {
+        return includeSnapshots
+                ? versions.isEmpty()
+                // the below means: the only versions that could be present in the collection
+                // are snapshots
+                : versions.stream().map(Object::toString).allMatch(ArtifactUtils::isSnapshot);
     }
 
     public VersionComparator getVersionComparator() {

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersionsCache.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersionsCache.java
@@ -22,24 +22,24 @@ package org.codehaus.mojo.versions.api;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.function.TriFunction;
+import org.apache.commons.lang3.tuple.Triple;
 
 /**
- * Utility providing a cached {@link ArtifactVersions#getNewestUpdate(Optional)} API
+ * Utility providing a cached {@link ArtifactVersions#getNewestUpdate(Optional, boolean)} API
  */
 public class ArtifactVersionsCache {
-    private BiFunction<AbstractVersionDetails, Optional<Segment>, ?> cachedFunction;
-
-    private Map<Pair<? extends AbstractVersionDetails, Optional<Segment>>, Object> updateCache = new HashMap<>();
+    private TriFunction<AbstractVersionDetails, Optional<Segment>, Boolean, ?> cachedFunction;
+    private Map<Triple<? extends AbstractVersionDetails, Optional<Segment>, Boolean>, Object> updateCache =
+            new HashMap<>();
 
     /**
      * Constructs a new instance given the concrete function for obtaining the details
      *
      * @param cachedFunction reference to the function computing the required information
      */
-    public ArtifactVersionsCache(BiFunction<AbstractVersionDetails, Optional<Segment>, ?> cachedFunction) {
+    public ArtifactVersionsCache(TriFunction<AbstractVersionDetails, Optional<Segment>, Boolean, ?> cachedFunction) {
         this.cachedFunction = cachedFunction;
     }
 
@@ -52,11 +52,14 @@ public class ArtifactVersionsCache {
      * @param <R> return type of the cached function
      * @param artifactVersions {@linkplain ArtifactVersions} object referring to the given dependency
      * @param updateScope      update scope
+     * @param allowSnapshots   whether snapshots should be included
      * @return last retrieved update information
      */
     @SuppressWarnings("unchecked")
-    public <V extends AbstractVersionDetails, R> R get(V artifactVersions, Optional<Segment> updateScope) {
+    public <V extends AbstractVersionDetails, R> R get(
+            V artifactVersions, Optional<Segment> updateScope, boolean allowSnapshots) {
         return (R) updateCache.computeIfAbsent(
-                Pair.of(artifactVersions, updateScope), pair -> cachedFunction.apply(pair.getLeft(), pair.getRight()));
+                Triple.of(artifactVersions, updateScope, allowSnapshots),
+                triple -> cachedFunction.apply(triple.getLeft(), triple.getMiddle(), triple.getRight()));
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionDetails.java
@@ -67,10 +67,6 @@ public interface VersionDetails {
      */
     void setCurrentVersion(String currentVersion);
 
-    boolean isIncludeSnapshots();
-
-    void setIncludeSnapshots(boolean includeSnapshots);
-
     /**
      * Retrieves the current version.
      *
@@ -86,14 +82,6 @@ public interface VersionDetails {
      * @since 1.0-beta-1
      */
     VersionComparator getVersionComparator();
-
-    /**
-     * Returns all the available versions in increasing order.
-     *
-     * @return all the available versions in increasing order.
-     * @since 1.0-alpha-3
-     */
-    ArtifactVersion[] getVersions();
 
     /**
      * Returns all available versions in increasing order.
@@ -113,16 +101,6 @@ public interface VersionDetails {
      * @since 1.0-alpha-3
      */
     ArtifactVersion[] getVersions(VersionRange versionRange, boolean includeSnapshots);
-
-    /**
-     * Returns all available versions within the specified bounds.
-     *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @return all available versions within the specified version range.
-     * @since 1.0-beta-1
-     */
-    ArtifactVersion[] getVersions(ArtifactVersion lowerBound, ArtifactVersion upperBound);
 
     /**
      * Returns all available versions within the specified bounds.
@@ -169,17 +147,6 @@ public interface VersionDetails {
      */
     ArtifactVersion getNewestVersion(
             VersionRange versionRange, Restriction restriction, boolean includeSnapshots, boolean allowDowngrade);
-
-    /**
-     * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
-     * <code>null</code> if no such version exists.
-     *
-     * @param lowerBound the lower bound or <code>null</code> if the lower limit is unbounded.
-     * @param upperBound the upper bound or <code>null</code> if the upper limit is unbounded.
-     * @return the latest version between lowerBound and upperBound or <code>null</code> if no version is available.
-     * @since 1.0-alpha-3
-     */
-    ArtifactVersion getNewestVersion(ArtifactVersion lowerBound, ArtifactVersion upperBound);
 
     /**
      * Returns the latest version newer than the specified lowerBound, but less than the specified upper bound or
@@ -322,28 +289,6 @@ public interface VersionDetails {
      * <code>null</code> if no such version exists.
      *
      * @param updateScope the update scope to include.
-     * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
-     *         version is available.
-     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
-     * @since 1.0-beta-1
-     */
-    ArtifactVersion getNewestUpdate(Optional<Segment> updateScope) throws InvalidSegmentException;
-
-    /**
-     * Returns the all versions newer than the specified current version, but within the specified update scope.
-     *
-     * @param updateScope the update scope to include.
-     * @return the all versions after currentVersion within the specified update scope.
-     * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
-     * @since 1.0-beta-1
-     */
-    ArtifactVersion[] getAllUpdates(Optional<Segment> updateScope) throws InvalidSegmentException;
-
-    /**
-     * Returns the newest version newer than the specified current version, but within the specified update scope or
-     * <code>null</code> if no such version exists.
-     *
-     * @param updateScope the update scope to include.
      * @param includeSnapshots <code>true</code> if snapshots are to be included.
      * @return the newest version after currentVersion within the specified update scope or <code>null</code> if no
      *         version is available.
@@ -357,7 +302,7 @@ public interface VersionDetails {
      * Returns the all versions newer than the specified current version, but within the specified update scope.
      *
      * @param updateScope the update scope to include.
-     * @param includeSnapshots <code>true</code> if snapshots are to be included.
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion within the specified update scope.
      * @throws InvalidSegmentException thrown if the updateScope is greater than the number of segments
      * @since 1.0-beta-1
@@ -368,19 +313,11 @@ public interface VersionDetails {
     /**
      * Returns the all versions newer than the specified current version
      *
+     * @param includeSnapshots {@code true} if snapshots are to be included.
      * @return the all versions after currentVersion
      * @since 2.13.0
      */
-    ArtifactVersion[] getAllUpdates();
-
-    /**
-     * Returns the all versions newer than the specified current version, but within the specified update scope.
-     *
-     * @param versionRange the version range to include.
-     * @return the all versions after currentVersion within the specified update scope.
-     * @since 1.0-beta-1
-     */
-    ArtifactVersion[] getAllUpdates(VersionRange versionRange);
+    ArtifactVersion[] getAllUpdates(boolean includeSnapshots);
 
     /**
      * Returns the all versions newer than the specified current version, but within the specified update scope.

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -149,6 +149,7 @@ public interface VersionsHelper {
     /**
      * Looks up the versions of the specified artifact that are available in either the local repository, or the
      * appropriate remote repositories.
+     * <b>The resulting {@link ArtifactVersions} instance will contain all versions, including snapshots.</b>
      *
      * @param artifact The artifact to look for versions of.
      * @param usePluginRepositories <code>true</code> will consult the pluginRepositories, while <code>false</code> will
@@ -163,6 +164,7 @@ public interface VersionsHelper {
     /**
      * Looks up the versions of the specified artifact that are available in either the local repository, or the
      * appropriate remote repositories.
+     * <b>The resulting {@link ArtifactVersions} instance will contain all versions, including snapshots.</b>
      *
      * @param artifact The artifact to look for versions of.
      * @param versionRange versionRange to restrict the search
@@ -176,27 +178,30 @@ public interface VersionsHelper {
             throws VersionRetrievalException;
 
     /**
-     * Looks up the updates for a set of dependencies.
+     * Returns a map of all possible updates per dependency. The lookup is done in parallel using
+     * {@code LOOKUP_PARALLEL_THREADS} threads.
      *
      * @param dependencies The set of {@link Dependency} instances to look up.
      * @param usePluginRepositories Search the plugin repositories.
-     * @return A map, keyed by dependency, with values of type {@link org.codehaus.mojo.versions.api.ArtifactVersions}.
-     * @throws VersionRetrievalException thrown if version resolution fails
-     * @since 1.0-beta-1
+     * @param allowSnapshots whether snapshots should be included
+     * @return map containing the ArtifactVersions object per dependency
      */
     Map<Dependency, ArtifactVersions> lookupDependenciesUpdates(
-            Set<Dependency> dependencies, boolean usePluginRepositories) throws VersionRetrievalException;
+            Set<Dependency> dependencies, boolean usePluginRepositories, boolean allowSnapshots)
+            throws VersionRetrievalException;
 
     /**
      * Creates an {@link org.codehaus.mojo.versions.api.ArtifactVersions} instance from a dependency.
      *
      * @param dependency The dependency.
      * @param usePluginRepositories Search the plugin repositories.
+     * @param allowSnapshots whether snapshots should be included
      * @return The details of updates to the dependency.
      * @throws VersionRetrievalException thrown if version resolution fails
      * @since 1.0-beta-1
      */
-    ArtifactVersions lookupDependencyUpdates(Dependency dependency, boolean usePluginRepositories)
+    ArtifactVersions lookupDependencyUpdates(
+            Dependency dependency, boolean usePluginRepositories, boolean allowSnapshots)
             throws VersionRetrievalException;
 
     /**

--- a/versions-enforcer/src/it-repo/dummy-api-2.2-SNAPSHOT.pom
+++ b/versions-enforcer/src/it-repo/dummy-api-2.2-SNAPSHOT.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>dummy-api</artifactId>
+  <version>2.2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+</project>

--- a/versions-enforcer/src/it/it-max-dependency-updates-005/invoker.properties
+++ b/versions-enforcer/src/it/it-max-dependency-updates-005/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = enforcer:enforce
+invoker.buildResult = succes

--- a/versions-enforcer/src/it/it-max-dependency-updates-005/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-005/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-max-dependency-upgrades</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>2.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@maven-enforcer-plugin.version@</version>
+        <goals>
+          <goal>enforce</goal>
+        </goals>
+        <configuration>
+          <rules>
+            <maxDependencyUpdates>
+              <maxUpdates>0</maxUpdates>
+            </maxDependencyUpdates>
+          </rules>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo.versions</groupId>
+            <artifactId>versions-enforcer</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/versions-enforcer/src/it/it-max-dependency-updates-006/invoker.properties
+++ b/versions-enforcer/src/it/it-max-dependency-updates-006/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = enforcer:enforce
+invoker.buildResult = failure

--- a/versions-enforcer/src/it/it-max-dependency-updates-006/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-006/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-max-dependency-upgrades</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>2.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@maven-enforcer-plugin.version@</version>
+        <goals>
+          <goal>enforce</goal>
+        </goals>
+        <configuration>
+          <rules>
+            <maxDependencyUpdates>
+              <maxUpdates>0</maxUpdates>
+              <allowSnapshots>true</allowSnapshots>
+            </maxDependencyUpdates>
+          </rules>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo.versions</groupId>
+            <artifactId>versions-enforcer</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
+++ b/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
@@ -244,6 +244,13 @@ public class MaxDependencyUpdates implements EnforcerRule2 {
     protected RuleSet ruleSet;
 
     /**
+     * Whether snapshots should be counted as updates. Default is {@code false}.
+     *
+     * @since 2.14.2
+     */
+    protected boolean allowSnapshots;
+
+    /**
      * Retrieves the maven project from metadata
      * @param ruleHelper EnforcerRuleHelper object
      * @return maven project
@@ -349,14 +356,14 @@ public class MaxDependencyUpdates implements EnforcerRule2 {
                     ? of(SUBINCREMENTAL)
                     : ignoreIncrementalUpdates ? of(INCREMENTAL) : ignoreMinorUpdates ? of(MINOR) : empty();
             List<ArtifactVersions> upgradable =
-                    versionsHelper.lookupDependenciesUpdates(dependencies, false).values().stream()
+                    versionsHelper.lookupDependenciesUpdates(dependencies, false, allowSnapshots).values().stream()
                             .filter(v -> v.getVersions(v.restrictionForIgnoreScope(ignoredSegment), true).length > 0)
                             .collect(Collectors.toList());
             if (upgradable.size() > maxUpdates) {
                 throw new EnforcerRuleException("More than " + maxUpdates + " upgradable artifacts detected: "
                         + upgradable.stream()
                                 .map(av -> av.getArtifact() + " -> ["
-                                        + Arrays.stream(av.getVersions())
+                                        + Arrays.stream(av.getVersions(allowSnapshots))
                                                 .map(ArtifactVersion::toString)
                                                 .collect(Collectors.joining(", "))
                                         + "]")

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
@@ -131,8 +131,8 @@ public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsRe
                     getHelper().lookupPluginsUpdates(pluginManagement, getAllowSnapshots());
 
             if (onlyUpgradable) {
-                pluginUpdates = filter(pluginUpdates, p -> p.getVersions().length > 0);
-                pluginManagementUpdates = filter(pluginManagementUpdates, p -> p.getVersions().length > 0);
+                pluginUpdates = filter(pluginUpdates, p -> !p.isEmpty(allowSnapshots));
+                pluginManagementUpdates = filter(pluginManagementUpdates, p -> !p.isEmpty(allowSnapshots));
             }
 
             renderReport(locale, sink, new PluginUpdatesModel(pluginUpdates, pluginManagementUpdates));
@@ -188,7 +188,7 @@ public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsRe
         for (String format : formats) {
             if ("html".equals(format)) {
                 rendererFactory
-                        .createReportRenderer(getOutputName(), sink, locale, model)
+                        .createReportRenderer(getOutputName(), sink, locale, model, allowSnapshots)
                         .render();
             } else if ("xml".equals(format)) {
                 Path outputDir = Paths.get(getProject().getBuild().getDirectory());
@@ -200,7 +200,7 @@ public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsRe
                     }
                 }
                 Path outputFile = outputDir.resolve(getOutputName() + ".xml");
-                new PluginUpdatesXmlReportRenderer(model, outputFile).render();
+                new PluginUpdatesXmlReportRenderer(model, outputFile, allowSnapshots).render();
             }
         }
     }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReportMojo.java
@@ -153,7 +153,7 @@ public abstract class AbstractPropertyUpdatesReportMojo extends AbstractVersions
         for (String format : this.formats) {
             if ("html".equals(format)) {
                 this.rendererFactory
-                        .createReportRenderer(getOutputName(), sink, locale, propertyUpdatesModel)
+                        .createReportRenderer(getOutputName(), sink, locale, propertyUpdatesModel, allowSnapshots)
                         .render();
             } else if ("xml".equals(format)) {
                 Path outputDir = Paths.get(getProject().getBuild().getDirectory());
@@ -165,7 +165,7 @@ public abstract class AbstractPropertyUpdatesReportMojo extends AbstractVersions
                     }
                 }
                 Path outputFile = outputDir.resolve(getOutputName() + ".xml");
-                new PropertyUpdatesXmlReportRenderer(propertyUpdatesModel, outputFile).render();
+                new PropertyUpdatesXmlReportRenderer(propertyUpdatesModel, outputFile, allowSnapshots).render();
             }
         }
     }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -421,7 +421,9 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         "Dependecy Management",
                         getLog());
 
-                logUpdates(getHelper().lookupDependenciesUpdates(dependencyManagement, false), "Dependency Management");
+                logUpdates(
+                        getHelper().lookupDependenciesUpdates(dependencyManagement, false, allowSnapshots),
+                        "Dependency Management");
             }
             if (isProcessingDependencies()) {
                 Set<Dependency> finalDependencyManagement = dependencyManagement;
@@ -440,7 +442,8 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                                 dependencyExcludes,
                                                 "Dependencies",
                                                 getLog()),
-                                        false),
+                                        false,
+                                        allowSnapshots),
                         "Dependencies");
             }
             if (isProcessPluginDependenciesInDependencyManagement()) {
@@ -453,7 +456,8 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                                 pluginManagementDependencyExcludes,
                                                 "Plugin Management Dependencies",
                                                 getLog()),
-                                        false),
+                                        false,
+                                        allowSnapshots),
                         "pluginManagement of plugins");
             }
             if (isProcessingPluginDependencies()) {
@@ -466,7 +470,8 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                                 pluginDependencyExcludes,
                                                 "Plugin Dependencies",
                                                 getLog()),
-                                        false),
+                                        false,
+                                        allowSnapshots),
                         "Plugin Dependencies");
             }
         } catch (VersionRetrievalException e) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ParentUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ParentUpdatesReportMojo.java
@@ -95,7 +95,6 @@ public class ParentUpdatesReportMojo extends AbstractVersionsReport<ParentUpdate
     protected void doGenerateReport(Locale locale, Sink sink) throws MavenReportException {
         try {
             ArtifactVersions artifactVersions = getHelper().lookupArtifactVersions(project.getParentArtifact(), false);
-            artifactVersions.setIncludeSnapshots(allowSnapshots);
             rendererFactory
                     .createReportRenderer(
                             getOutputName(),
@@ -118,7 +117,8 @@ public class ParentUpdatesReportMojo extends AbstractVersionsReport<ParentUpdate
                                                     .getArtifact()
                                                     .getClassifier())
                                             .build(),
-                                    artifactVersions))
+                                    artifactVersions),
+                            allowSnapshots)
                     .render();
         } catch (VersionRetrievalException e) {
             throw new MavenReportException(e.getMessage(), e);

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/AbstractVersionsReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/AbstractVersionsReportRenderer.java
@@ -35,7 +35,7 @@ import org.apache.maven.model.Dependency;
 import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.ArtifactVersionsCache;
-import org.codehaus.mojo.versions.api.ReportRenderer;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 import org.codehaus.plexus.i18n.I18N;
 
 import static java.util.Optional.empty;
@@ -69,8 +69,9 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
 
     protected final SinkEventAttributes headerAttributes = new SinkEventAttributeSet(SinkEventAttributes.WIDTH, "30%");
 
-    protected AbstractVersionsReportRenderer(I18N i18n, Sink sink, Locale locale, String bundleName, T model) {
-        super(sink, i18n, locale, bundleName);
+    protected AbstractVersionsReportRenderer(
+            I18N i18n, Sink sink, Locale locale, String bundleName, T model, boolean allowSnapshots) {
+        super(sink, i18n, locale, bundleName, allowSnapshots);
         this.model = model;
     }
 
@@ -214,7 +215,7 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
 
     protected void renderSummaryTableRow(Dependency artifact, ArtifactVersions details, boolean includeScope) {
         details.setCurrentVersion(artifact.getVersion());
-        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty());
+        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty(), isAllowSnapshots());
         boolean upToDate = allUpdates == null || allUpdates.length == 0;
 
         sink.tableRow();
@@ -238,14 +239,14 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
      * @param details the artifact for which to render the newest versions.
      */
     protected void renderNewestVersions(AbstractVersionDetails details) {
-        renderBoldCell(newestUpdateCache.get(details, of(SUBINCREMENTAL)));
-        renderBoldCell(newestUpdateCache.get(details, of(INCREMENTAL)));
-        renderBoldCell(newestUpdateCache.get(details, of(MINOR)));
-        renderBoldCell(newestUpdateCache.get(details, of(MAJOR)));
+        renderBoldCell(newestUpdateCache.get(details, of(SUBINCREMENTAL), isAllowSnapshots()));
+        renderBoldCell(newestUpdateCache.get(details, of(INCREMENTAL), isAllowSnapshots()));
+        renderBoldCell(newestUpdateCache.get(details, of(MINOR), isAllowSnapshots()));
+        renderBoldCell(newestUpdateCache.get(details, of(MAJOR), isAllowSnapshots()));
     }
 
     protected void renderDependencyDetailTable(Dependency artifact, ArtifactVersions details, boolean includeScope) {
-        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty());
+        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty(), isAllowSnapshots());
         boolean upToDate = allUpdates == null || allUpdates.length == 0;
 
         sink.table();
@@ -305,19 +306,19 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
      * @param details the artifact for which to render the status.
      */
     protected void renderStatus(AbstractVersionDetails details) {
-        if (newestUpdateCache.get(details, of(SUBINCREMENTAL)) != null) {
+        if (newestUpdateCache.get(details, of(SUBINCREMENTAL), isAllowSnapshots()) != null) {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text(getText("report.otherUpdatesAvailable"));
-        } else if (newestUpdateCache.get(details, of(INCREMENTAL)) != null) {
+        } else if (newestUpdateCache.get(details, of(INCREMENTAL), isAllowSnapshots()) != null) {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text(getText("report.incrementalUpdatesAvailable"));
-        } else if (newestUpdateCache.get(details, of(MINOR)) != null) {
+        } else if (newestUpdateCache.get(details, of(MINOR), isAllowSnapshots()) != null) {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text(getText("report.minorUpdatesAvailable"));
-        } else if (newestUpdateCache.get(details, of(MAJOR)) != null) {
+        } else if (newestUpdateCache.get(details, of(MAJOR), isAllowSnapshots()) != null) {
             renderWarningIcon();
             sink.nonBreakingSpace();
             sink.text(getText("report.majorUpdatesAvailable"));
@@ -398,19 +399,19 @@ public abstract class AbstractVersionsReportRenderer<T> extends VersionsReportRe
      */
     protected String getLabel(ArtifactVersion version, AbstractVersionDetails details) {
 
-        if (equals(version, newestUpdateCache.get(details, of(SUBINCREMENTAL)))) {
+        if (equals(version, newestUpdateCache.get(details, of(SUBINCREMENTAL), isAllowSnapshots()))) {
             return getText("report.latestSubIncremental");
         }
 
-        if (equals(version, newestUpdateCache.get(details, of(INCREMENTAL)))) {
+        if (equals(version, newestUpdateCache.get(details, of(INCREMENTAL), isAllowSnapshots()))) {
             return getText("report.latestIncremental");
         }
 
-        if (equals(version, newestUpdateCache.get(details, of(MINOR)))) {
+        if (equals(version, newestUpdateCache.get(details, of(MINOR), isAllowSnapshots()))) {
             return getText("report.latestMinor");
         }
 
-        if (equals(version, newestUpdateCache.get(details, of(MAJOR)))) {
+        if (equals(version, newestUpdateCache.get(details, of(MAJOR), isAllowSnapshots()))) {
             return getText("report.latestMajor");
         }
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/DependencyUpdatesReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/DependencyUpdatesReportRenderer.java
@@ -35,8 +35,9 @@ import org.codehaus.plexus.i18n.I18N;
  */
 public class DependencyUpdatesReportRenderer<K extends DependencyUpdatesModel>
         extends AbstractVersionsReportRenderer<K> {
-    public DependencyUpdatesReportRenderer(I18N i18n, Sink sink, Locale locale, String bundleName, K model) {
-        super(i18n, sink, locale, bundleName, model);
+    public DependencyUpdatesReportRenderer(
+            I18N i18n, Sink sink, Locale locale, String bundleName, K model, boolean allowSnapshots) {
+        super(i18n, sink, locale, bundleName, model, allowSnapshots);
     }
 
     /**
@@ -78,7 +79,7 @@ public class DependencyUpdatesReportRenderer<K extends DependencyUpdatesModel>
 
     @Override
     protected OverviewStats computeOverviewStats() {
-        return OverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache);
+        return OverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache, isAllowSnapshots());
     }
 
     protected void renderDependencyDetail(Dependency artifact, ArtifactVersions details) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/OverviewStats.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/OverviewStats.java
@@ -57,22 +57,23 @@ public class OverviewStats {
      * @param updates collection of all version updates, typically from
      * {@linkplain org.codehaus.mojo.versions.reporting.model.DependencyUpdatesModel#getAllUpdates()}
      * @param cache if not null, cache to retrieve the version information, initialised with
-     * the {@link ArtifactVersions#getNewestUpdate(Optional)} update information
+     * the {@link ArtifactVersions#getNewestUpdate(Optional, boolean)} update information
      * @param <T> subclass of {@linkplain OverviewStats}
      * @param <V> subclass of {@linkplain ArtifactVersions}
+     * @param allowSnapshots whether snapshots should be included
      * @return instance of the {@linkplain OverviewStats}
      */
     public static <T extends OverviewStats, V extends AbstractVersionDetails> T fromUpdates(
-            Collection<V> updates, ArtifactVersionsCache cache) {
+            Collection<V> updates, ArtifactVersionsCache cache, boolean allowSnapshots) {
         OverviewStats stats = new OverviewStats();
         updates.forEach(details -> {
-            if (getNewestUpdate(cache, details, of(SUBINCREMENTAL)) != null) {
+            if (getNewestUpdate(cache, details, of(SUBINCREMENTAL), allowSnapshots) != null) {
                 stats.incrementAny();
-            } else if (getNewestUpdate(cache, details, of(INCREMENTAL)) != null) {
+            } else if (getNewestUpdate(cache, details, of(INCREMENTAL), allowSnapshots) != null) {
                 stats.incrementIncremental();
-            } else if (getNewestUpdate(cache, details, of(MINOR)) != null) {
+            } else if (getNewestUpdate(cache, details, of(MINOR), allowSnapshots) != null) {
                 stats.incrementMinor();
-            } else if (getNewestUpdate(cache, details, of(MAJOR)) != null) {
+            } else if (getNewestUpdate(cache, details, of(MAJOR), allowSnapshots) != null) {
                 stats.incrementMajor();
             } else {
                 stats.incrementUpToDate();
@@ -82,8 +83,10 @@ public class OverviewStats {
     }
 
     protected static <V extends AbstractVersionDetails> ArtifactVersion getNewestUpdate(
-            ArtifactVersionsCache cache, V details, Optional<Segment> segment) {
-        return cache != null ? cache.get(details, segment) : details.getNewestUpdate(segment);
+            ArtifactVersionsCache cache, V details, Optional<Segment> segment, boolean allowSnapshots) {
+        return cache != null
+                ? cache.get(details, segment, allowSnapshots)
+                : details.getNewestUpdate(segment, allowSnapshots);
     }
 
     public int getMajor() {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ParentUpdatesReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ParentUpdatesReportRenderer.java
@@ -30,8 +30,8 @@ import org.codehaus.plexus.i18n.I18N;
  */
 public class ParentUpdatesReportRenderer extends DependencyUpdatesReportRenderer<ParentUpdatesModel> {
     public ParentUpdatesReportRenderer(
-            I18N i18n, Sink sink, Locale locale, String bundleName, ParentUpdatesModel model) {
-        super(i18n, sink, locale, bundleName, model);
+            I18N i18n, Sink sink, Locale locale, String bundleName, ParentUpdatesModel model, boolean allowSnapshots) {
+        super(i18n, sink, locale, bundleName, model, allowSnapshots);
     }
 
     @Override

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PluginOverviewStats.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PluginOverviewStats.java
@@ -53,22 +53,23 @@ public class PluginOverviewStats extends OverviewStats {
      *
      * @param updates collection of all version updates, typically from {@linkplain PluginUpdatesModel#getAllUpdates()}
      * @param cache if not null, cache to retrieve the version information, initialised with
-     * the {@link ArtifactVersions#getNewestUpdate(Optional)} update information
+     * the {@link ArtifactVersions#getNewestUpdate(Optional, boolean)} update information
      * @param <T> always equal to {@linkplain PluginOverviewStats}
      * @param <V> always equal to {@linkplain PluginUpdatesDetails}
+     * @param allowSnapshots whether snapshots should be included
      * @return instance of the {@linkplain PluginOverviewStats}, initialised with the update information
      */
     public static <T extends OverviewStats, V extends AbstractVersionDetails> T fromUpdates(
-            Collection<V> updates, ArtifactVersionsCache cache) {
+            Collection<V> updates, ArtifactVersionsCache cache, boolean allowSnapshots) {
         PluginOverviewStats stats = new PluginOverviewStats();
         updates.forEach(details -> {
-            if (getNewestUpdate(cache, details, of(SUBINCREMENTAL)) != null) {
+            if (getNewestUpdate(cache, details, of(SUBINCREMENTAL), allowSnapshots) != null) {
                 stats.incrementAny();
-            } else if (getNewestUpdate(cache, details, of(INCREMENTAL)) != null) {
+            } else if (getNewestUpdate(cache, details, of(INCREMENTAL), allowSnapshots) != null) {
                 stats.incrementIncremental();
-            } else if (getNewestUpdate(cache, details, of(MINOR)) != null) {
+            } else if (getNewestUpdate(cache, details, of(MINOR), allowSnapshots) != null) {
                 stats.incrementMinor();
-            } else if (getNewestUpdate(cache, details, of(MAJOR)) != null) {
+            } else if (getNewestUpdate(cache, details, of(MAJOR), allowSnapshots) != null) {
                 stats.incrementMajor();
             } else {
                 stats.incrementUpToDate();

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PluginUpdatesReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PluginUpdatesReportRenderer.java
@@ -40,8 +40,8 @@ import static java.util.Optional.empty;
 public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<PluginUpdatesModel> {
 
     public PluginUpdatesReportRenderer(
-            I18N i18n, Sink sink, Locale locale, String bundleName, PluginUpdatesModel model) {
-        super(i18n, sink, locale, bundleName, model);
+            I18N i18n, Sink sink, Locale locale, String bundleName, PluginUpdatesModel model, boolean allowSnapshots) {
+        super(i18n, sink, locale, bundleName, model, allowSnapshots);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<
      */
     @Override
     protected PluginOverviewStats computeOverviewStats() {
-        return PluginOverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache);
+        return PluginOverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache, isAllowSnapshots());
     }
 
     @Override
@@ -178,7 +178,7 @@ public class PluginUpdatesReportRenderer extends AbstractVersionsReportRenderer<
 
     private void renderPluginDetailTable(PluginUpdatesDetails details) {
         // warning: using caches here might break plugin report
-        ArtifactVersion[] allUpdates = details.getAllUpdates(empty());
+        ArtifactVersion[] allUpdates = details.getAllUpdates(empty(), isAllowSnapshots());
         boolean upToDate = allUpdates == null || allUpdates.length == 0;
 
         sink.table();

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PropertyUpdatesReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/PropertyUpdatesReportRenderer.java
@@ -38,8 +38,13 @@ import static java.util.Optional.empty;
  */
 public class PropertyUpdatesReportRenderer extends AbstractVersionsReportRenderer<PropertyUpdatesModel> {
     public PropertyUpdatesReportRenderer(
-            I18N i18n, Sink sink, Locale locale, String bundleName, PropertyUpdatesModel model) {
-        super(i18n, sink, locale, bundleName, model);
+            I18N i18n,
+            Sink sink,
+            Locale locale,
+            String bundleName,
+            PropertyUpdatesModel model,
+            boolean allowSnapshots) {
+        super(i18n, sink, locale, bundleName, model, allowSnapshots);
     }
 
     @Override
@@ -91,7 +96,7 @@ public class PropertyUpdatesReportRenderer extends AbstractVersionsReportRendere
     }
 
     private void renderPropertySummaryTableRow(Property property, PropertyVersions details) {
-        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty());
+        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty(), isAllowSnapshots());
         boolean upToDate = allUpdates == null || allUpdates.length == 0;
 
         sink.tableRow();
@@ -107,7 +112,7 @@ public class PropertyUpdatesReportRenderer extends AbstractVersionsReportRendere
     }
 
     protected void renderPropertyDetailTable(Property property, PropertyVersions details) {
-        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty());
+        ArtifactVersion[] allUpdates = allUpdatesCache.get(details, empty(), isAllowSnapshots());
         boolean upToDate = allUpdates == null || allUpdates.length == 0;
 
         sink.table();
@@ -163,7 +168,7 @@ public class PropertyUpdatesReportRenderer extends AbstractVersionsReportRendere
 
     @Override
     protected OverviewStats computeOverviewStats() {
-        return OverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache);
+        return OverviewStats.fromUpdates(model.getAllUpdates().values(), newestUpdateCache, isAllowSnapshots());
     }
 
     private void renderPropertyDetail(Property property, PropertyVersions details) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ReportRendererFactory.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ReportRendererFactory.java
@@ -22,7 +22,7 @@ package org.codehaus.mojo.versions.reporting;
 import java.util.Locale;
 
 import org.apache.maven.doxia.sink.Sink;
-import org.codehaus.mojo.versions.api.ReportRenderer;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 
 /**
  * Factory for report renderers
@@ -37,9 +37,11 @@ public interface ReportRendererFactory {
      * @param sink sink to use for rendering
      * @param locale locale to use for rendering
      * @param model data to render
+     * @param allowSnapshots whether snapshots should be included
      * @return new report renderer
      * @throws IllegalArgumentException thrown if the report with the given name could not be found
      */
-    <T extends ReportRenderer, U> T createReportRenderer(String reportName, Sink sink, Locale locale, U model)
+    <T extends ReportRenderer, U> T createReportRenderer(
+            String reportName, Sink sink, Locale locale, U model, boolean allowSnapshots)
             throws IllegalArgumentException;
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ReportRendererFactoryImpl.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/ReportRendererFactoryImpl.java
@@ -26,11 +26,11 @@ import javax.inject.Singleton;
 import java.util.Locale;
 
 import org.apache.maven.doxia.sink.Sink;
-import org.codehaus.mojo.versions.api.ReportRenderer;
 import org.codehaus.mojo.versions.reporting.model.DependencyUpdatesModel;
 import org.codehaus.mojo.versions.reporting.model.ParentUpdatesModel;
 import org.codehaus.mojo.versions.reporting.model.PluginUpdatesModel;
 import org.codehaus.mojo.versions.reporting.model.PropertyUpdatesModel;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -58,20 +58,24 @@ public class ReportRendererFactoryImpl implements ReportRendererFactory {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends ReportRenderer, U> T createReportRenderer(String reportName, Sink sink, Locale locale, U model)
+    public <T extends ReportRenderer, U> T createReportRenderer(
+            String reportName, Sink sink, Locale locale, U model, boolean allowSnapshots)
             throws IllegalArgumentException {
         if (DEPENDENCY_UPDATES_REPORT.equals(reportName) || DEPENDENCY_UPDATES_AGGREGATE_REPORT.equals(reportName)) {
             return (T) new DependencyUpdatesReportRenderer<>(
-                    i18N, sink, locale, reportName, (DependencyUpdatesModel) model);
+                    i18N, sink, locale, reportName, (DependencyUpdatesModel) model, allowSnapshots);
         }
         if (PLUGIN_UPDATES_REPORT.equals(reportName) || PLUGIN_UPDATES_AGGREGATE_REPORT.equals(reportName)) {
-            return (T) new PluginUpdatesReportRenderer(i18N, sink, locale, reportName, (PluginUpdatesModel) model);
+            return (T) new PluginUpdatesReportRenderer(
+                    i18N, sink, locale, reportName, (PluginUpdatesModel) model, allowSnapshots);
         }
         if (PROPERTY_UPDATES_REPORT.equals(reportName) || PROPERTY_UPDATES_AGGREGATE_REPORT.equals(reportName)) {
-            return (T) new PropertyUpdatesReportRenderer(i18N, sink, locale, reportName, (PropertyUpdatesModel) model);
+            return (T) new PropertyUpdatesReportRenderer(
+                    i18N, sink, locale, reportName, (PropertyUpdatesModel) model, allowSnapshots);
         }
         if (PARENT_UPDATES_REPORT.equals(reportName)) {
-            return (T) new ParentUpdatesReportRenderer(i18N, sink, locale, reportName, (ParentUpdatesModel) model);
+            return (T) new ParentUpdatesReportRenderer(
+                    i18N, sink, locale, reportName, (ParentUpdatesModel) model, allowSnapshots);
         }
         throw new IllegalArgumentException("Invalid report name: " + reportName);
     }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/VersionsReportRendererBase.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/VersionsReportRendererBase.java
@@ -25,19 +25,23 @@ import java.util.Locale;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.reporting.AbstractMavenReportRenderer;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
  * Base class over AbstractVersionsReportRenderer providing base
  * utility methods
  */
-public abstract class VersionsReportRendererBase extends AbstractMavenReportRenderer {
+public abstract class VersionsReportRendererBase extends AbstractMavenReportRenderer implements ReportRenderer {
     /**
      * Internationalization component.
      *
      * @since 1.0-beta-1
      */
     protected final I18N i18n;
+
+    private final boolean allowSnapshots;
+
     /**
      * The locale we are rendering for.
      *
@@ -51,15 +55,21 @@ public abstract class VersionsReportRendererBase extends AbstractMavenReportRend
      */
     protected String bundleName;
 
-    public VersionsReportRendererBase(Sink sink, I18N i18n, Locale locale, String bundleName) {
+    public VersionsReportRendererBase(Sink sink, I18N i18n, Locale locale, String bundleName, boolean allowSnapshots) {
         super(sink);
         this.i18n = i18n;
         this.locale = locale;
         this.bundleName = bundleName;
+        this.allowSnapshots = allowSnapshots;
     }
 
     public String getTitle() {
         return getText("report.title");
+    }
+
+    @Override
+    public boolean isAllowSnapshots() {
+        return allowSnapshots;
     }
 
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/AbstractUpdatesModel.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/AbstractUpdatesModel.java
@@ -28,7 +28,7 @@ import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
 
 /**
- * Base class for using with the {@linkplain org.codehaus.mojo.versions.api.ReportRenderer} API
+ * Base class for using with the {@linkplain org.codehaus.mojo.versions.reporting.util.ReportRenderer} API
  * @param <V> class extending ArtifactVersion in the constructor
  */
 public abstract class AbstractUpdatesModel<V extends ArtifactVersions> {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/DependencyUpdatesModel.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/DependencyUpdatesModel.java
@@ -23,9 +23,10 @@ import java.util.Map;
 
 import org.apache.maven.model.Dependency;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 
 /**
- * Model class for using with the {@linkplain org.codehaus.mojo.versions.api.ReportRenderer} API
+ * Model class for using with the {@linkplain ReportRenderer} API
  */
 public class DependencyUpdatesModel extends AbstractUpdatesModel<ArtifactVersions> {
     public DependencyUpdatesModel(

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/ParentUpdatesModel.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/ParentUpdatesModel.java
@@ -21,12 +21,13 @@ package org.codehaus.mojo.versions.reporting.model;
 
 import org.apache.maven.model.Dependency;
 import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 
 /**
- * Model class for using with the {@linkplain org.codehaus.mojo.versions.api.ReportRenderer} API
+ * Model class for using with the {@linkplain ReportRenderer} API
  */
 public class ParentUpdatesModel extends DependencyUpdatesModel {
     public ParentUpdatesModel(Dependency parent, ArtifactVersions dependencyUpdates) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/PluginUpdatesModel.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/PluginUpdatesModel.java
@@ -23,10 +23,11 @@ import java.util.Map;
 
 import org.apache.maven.model.Plugin;
 import org.codehaus.mojo.versions.api.PluginUpdatesDetails;
+import org.codehaus.mojo.versions.reporting.util.ReportRenderer;
 import org.codehaus.mojo.versions.utils.DependencyBuilder;
 
 /**
- * Model class for using with the {@linkplain org.codehaus.mojo.versions.api.ReportRenderer} API
+ * Model class for using with the {@linkplain ReportRenderer} API
  */
 public class PluginUpdatesModel extends AbstractUpdatesModel<PluginUpdatesDetails> {
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/PropertyUpdatesModel.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/model/PropertyUpdatesModel.java
@@ -27,7 +27,7 @@ import org.codehaus.mojo.versions.api.PropertyVersions;
 import org.codehaus.mojo.versions.utils.PropertyComparator;
 
 /**
- * Model class for using with the {@linkplain org.codehaus.mojo.versions.api.ReportRenderer} API
+ * Model class for using with the {@linkplain org.apache.maven.reporting.MavenReportRenderer} API
  */
 public class PropertyUpdatesModel {
     private final Map<Property, PropertyVersions> allUpdates;

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/util/ReportRenderer.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/reporting/util/ReportRenderer.java
@@ -1,4 +1,4 @@
-package org.codehaus.mojo.versions.api;
+package org.codehaus.mojo.versions.reporting.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,12 +19,16 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import org.apache.maven.reporting.MavenReportRenderer;
+
 /**
  * Common interface for reporting components
  */
-public interface ReportRenderer {
+public interface ReportRenderer extends MavenReportRenderer {
+
     /**
-     * Renders the report
+     * If {@code true}, the report renderer will include snapshots in the report
+     * @return if {@code true}, the report renderer will include snapshots in the report
      */
-    void render();
+    boolean isAllowSnapshots();
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/xml/CommonXmlReportRendererUtils.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/xml/CommonXmlReportRendererUtils.java
@@ -36,8 +36,12 @@ import static java.util.Optional.ofNullable;
  * Common utils for Xml report renderers
  */
 class CommonXmlReportRendererUtils {
-    static void setSection(AbstractVersionDetails versions, Segment segment, Consumer<List<String>> setterFunction) {
-        ofNullable(versions.getAllUpdates(of(segment)))
+    static void setSection(
+            AbstractVersionDetails versions,
+            Segment segment,
+            Consumer<List<String>> setterFunction,
+            boolean allowSnapshots) {
+        ofNullable(versions.getAllUpdates(of(segment), allowSnapshots))
                 .map(v -> Arrays.stream(v).map(ArtifactVersion::toString).collect(Collectors.toList()))
                 .ifPresent(setterFunction);
     }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRendererTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesXmlRendererTest.java
@@ -87,7 +87,8 @@ public class DependencyUpdatesXmlRendererTest {
                                                         new DefaultArtifactVersion("2.0.0")),
                                                 new MavenVersionComparator())),
                                 emptyMap()),
-                        tempFile)
+                        tempFile,
+                        false)
                 .render();
         String output = String.join("", Files.readAllLines(tempFile)).replaceAll(">\\s*<", "><");
 

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PluginUpdatesXmlRendererTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PluginUpdatesXmlRendererTest.java
@@ -87,7 +87,7 @@ public class PluginUpdatesXmlRendererTest {
                                                 new MavenVersionComparator())),
                                 false)),
                 emptyMap());
-        new PluginUpdatesXmlReportRenderer(pluginUpdates, tempFile).render();
+        new PluginUpdatesXmlReportRenderer(pluginUpdates, tempFile, false).render();
 
         String output = String.join("", Files.readAllLines(tempFile)).replaceAll(">\\s*<", "><");
 


### PR DESCRIPTION
allowSnapshots was not an explicit argument in many retrieval operations. Instead, it was assumed that the user would call `AbstractVersionDetails.setIncludeSnapshots()` to set it. This class was used as a container for this value so that it could be passed to report generators.

So, I'm clearing this up and also passing the value **explicitly** where needed. 
