### PR TITLE
Resolves #474: Add property support to UseDepVersion

### DIFF
--- a/versions-common/pom.xml
+++ b/versions-common/pom.xml
@@ -60,11 +60,9 @@
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- woodstox only used for unit tests -->
     <dependency>
       <groupId>com.fasterxml.woodstox</groupId>
       <artifactId>woodstox-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/ModifiedPomXMLEventReader.java
@@ -514,4 +514,8 @@ public class ModifiedPomXMLEventReader implements XMLEventReader {
         MavenXpp3Reader reader = new MavenXpp3Reader();
         return reader.read(new StringReader(pom.toString()));
     }
+
+    public String getPath() {
+        return path;
+    }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -94,7 +94,7 @@ public class MavenProjectUtils {
                 log.debug("dependency from pom: " + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":"
                         + dependency.getVersion() + ":" + dependency.getScope());
                 if (dependency.getVersion() == null) {
-                    // get parent and get the information from there.
+                    // getModel parent and getModel the information from there.
                     if (project.hasParent()) {
                         log.debug("Reading parent dependencyManagement information");
                         DependencyManagement parentProjectDependencyManagement = processDependencyManagementTransitive
@@ -112,10 +112,10 @@ public class MavenProjectUtils {
                             }
                         }
                     } else {
-                        String message = "We can't get the version for the dependency " + dependency.getGroupId() + ":"
-                                + dependency.getArtifactId() + " because there does not exist a parent.";
+                        String message = "We can't getModel the version for the dependency " + dependency.getGroupId()
+                                + ":" + dependency.getArtifactId() + " because there does not exist a parent.";
                         log.error(message);
-                        // Throw error because we will not able to get a version for a dependency.
+                        // Throw error because we will not able to getModel a version for a dependency.
                         throw new VersionRetrievalException(message);
                     }
                 } else {

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/ModelNode.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/ModelNode.java
@@ -1,0 +1,98 @@
+package org.codehaus.mojo.versions.utils;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Optional;
+
+import org.apache.maven.model.Model;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+
+/**
+ * Represents a navigable tree of {@link Model} instances.
+ */
+public class ModelNode {
+    private ModelNode parent;
+    private Model item;
+    private ModifiedPomXMLEventReader pom;
+
+    /**
+     * Creates a root node (without a parent).
+     *
+     * @param model {@link Model} instance
+     * @param pom {@link ModifiedPomXMLEventReader} instance
+     */
+    public ModelNode(Model model, ModifiedPomXMLEventReader pom) {
+        this(null, model, pom);
+    }
+
+    /**
+     * Creates a new instance with a parent node.
+     *
+     * @param parent parent node
+     * @param model {@link Model} instance
+     * @param pom {@link ModifiedPomXMLEventReader} instance
+     */
+    public ModelNode(ModelNode parent, Model model, ModifiedPomXMLEventReader pom) {
+        this.parent = parent;
+        this.item = model;
+        this.pom = pom;
+    }
+
+    /**
+     * Returns the {@link Model} instance associated with the given node.
+     *
+     * @return {@link Model} associated with the given node, never {@code null}.
+     */
+    public Model getModel() {
+        return item;
+    }
+
+    /**
+     * Gets the parent node.
+     *
+     * @return The parent node of this node or {@link Optional#empty()}, never {@code null}.
+     */
+    public Optional<ModelNode> getParent() {
+        return Optional.ofNullable(parent);
+    }
+
+    /**
+     * Gets the {@link ModifiedPomXMLEventReader} instance
+     *
+     * @return the {@link ModifiedPomXMLEventReader} instance
+     */
+    public ModifiedPomXMLEventReader getModifiedPomXMLEventReader() {
+        return pom;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof ModelNode) {
+            ModelNode other = (ModelNode) o;
+            return item.equals(other.item) && (parent == null || parent.equals(other.parent)) && pom.equals(other.pom);
+        }
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:MagicNumber")
+    public int hashCode() {
+        return 13 * item.hashCode() + (parent == null ? 0 : 23 * parent.hashCode()) + 7 * pom.hashCode();
+    }
+}

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childA/grandchild/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childA/grandchild/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>childA</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>grandchild</artifactId>
+    <packaging>pom</packaging>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childA/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childA/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>grandparent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>childA</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <a>a1</a>
+    </properties>
+
+    <modules>
+        <module>grandchild</module>
+    </modules>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childB/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/childB/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>grandparent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>childB</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <b>b</b>
+    </properties>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/findProperty/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>grandparent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <a>a</a>
+    </properties>
+
+    <modules>
+        <module>childA</module>
+        <module>childB</module>
+    </modules>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childA/grandchild/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childA/grandchild/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>childA</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>grandchild</artifactId>
+    <packaging>pom</packaging>
+
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childA/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childA/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>grandparent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>childA</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>grandchild</module>
+    </modules>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childB/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/childB/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>default-group</groupId>
+        <artifactId>grandparent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>childB</artifactId>
+    <packaging>pom</packaging>
+</project>

--- a/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/pom.xml
+++ b/versions-common/src/test/resources/org/codehaus/mojo/versions/api/getRawModelTree/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>grandparent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>childA</module>
+        <module>childB</module>
+    </modules>
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-001/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-001/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals= ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dincludes=localhost -DdepVersion=1.0.1
+invoker.buildResult = success

--- a/versions-maven-plugin/src/it/it-use-dep-version-001/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-001/pom.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-dep-version-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-001/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-002/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-002/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals= ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dincludes=localhost -DdepVersion=1.0.1
+invoker.buildResult = success

--- a/versions-maven-plugin/src/it/it-use-dep-version-002/it-use-dep-version-002-child/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-002/it-use-dep-version-002-child/pom.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>it-use-dep-version-002</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>it-use-dep-version-002-child</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-002/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-002/pom.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-dep-version-002</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>it-use-dep-version-002-child</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-002/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-002/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def parent = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert parent.dependencies.dependency.version == '1.0.1'
+
+def child = new XmlSlurper().parse( new File( basedir, 'it-use-dep-version-002-child/pom.xml' ) )
+assert child.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-003/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-003/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals= ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dincludes=localhost -DdepVersion=1.0.1
+invoker.buildResult = success

--- a/versions-maven-plugin/src/it/it-use-dep-version-003/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-003/pom.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-dep-version-003</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <profiles>
+    <profile>
+      <id>test-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-api</artifactId>
+          <version>1.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-003/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-003/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.profiles.profile.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-004/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-004/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals= ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dincludes=localhost -DdepVersion=1.0.1 -DprocessProperties=true
+invoker.buildResult = success

--- a/versions-maven-plugin/src/it/it-use-dep-version-004/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-004/pom.xml
@@ -1,0 +1,51 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-use-dep-version-004</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <revision>1.0</revision>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>test-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-api</artifactId>
+          <version>${revision}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-004/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-004/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.properties.revision == '1.0.1'
+assert project.profiles.profile.dependencies.dependency.version == '${revision}'

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
@@ -193,7 +193,7 @@ public abstract class AbstractDependencyUpdatesReportMojo extends AbstractVersio
         } else {
             if (project.getOriginalModel().getDependencyManagement() != null
                     && project.getOriginalModel().getDependencyManagement().getDependencies() != null) {
-                // Using the original model to get the original dependencyManagement entries and
+                // Using the original model to getModel the original dependencyManagement entries and
                 // not the interpolated model.
                 // TODO: I'm not 100% sure if this will work correctly in all cases.
                 for (Dependency dep :

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -119,7 +119,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
      * @since 1.0-alpha-3
      */
     @Parameter(property = "generateBackupPoms", defaultValue = "true")
-    private boolean generateBackupPoms;
+    protected boolean generateBackupPoms;
 
     /**
      * Whether to allow snapshots when searching for the latest version of an artifact.
@@ -298,19 +298,6 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
         final ArtifactVersions artifactVersions =
                 getHelper().lookupArtifactVersions(artifact, versionRange, usePluginRepositories);
         return artifactVersions.getNewestVersion(versionRange, null, includeSnapshots, false);
-    }
-
-    /**
-     * Gets the property value that is defined in the pom. This is an extension point to allow updating a file external
-     * to the reactor.
-     *
-     * @param pom      The pom.
-     * @param property The property.
-     * @return The value as defined in the pom or <code>null</code> if not defined.
-     * @since 1.0-alpha-1
-     */
-    protected String getPropertyValue(StringBuilder pom, String property) {
-        return project.getProperties().getProperty(property);
     }
 
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -248,7 +248,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Gets the plugin management plugins of a specific project.
      *
-     * @param model the model to get the plugin management plugins from.
+     * @param model the model to getModel the plugin management plugins from.
      * @return The map of effective plugin versions keyed by coordinates.
      * @since 1.0-alpha-1
      */
@@ -729,7 +729,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Returns a set of Strings which correspond to the plugin coordinates where there is a version specified.
      *
-     * @param pomContents The project to get the plugins with versions specified.
+     * @param pomContents The project to getModel the plugins with versions specified.
      * @param path        Path that points to the source of the XML
      * @return a set of Strings which correspond to the plugin coordinates where there is a version specified.
      */
@@ -818,7 +818,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Gets the build plugins of a specific project.
      *
-     * @param model                the model to get the build plugins from.
+     * @param model                the model to getModel the build plugins from.
      * @param onlyIncludeInherited {@code true} to only return the plugins definitions that will be inherited by
      *                             child projects.
      * @return The map of effective plugin versions keyed by coordinates.
@@ -850,7 +850,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Returns the lifecycle plugins of a specific project.
      *
-     * @param project the project to get the lifecycle plugins from.
+     * @param project the project to getModel the lifecycle plugins from.
      * @return The map of effective plugin versions keyed by coordinates.
      * @throws org.apache.maven.plugin.MojoExecutionException if things go wrong.
      * @since 1.0-alpha-1
@@ -887,7 +887,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Returns all the parent projects of the specified project, with the root project first.
      *
-     * @param project The maven project to get the parents of
+     * @param project The maven project to getModel the parents of
      * @return the parent projects of the specified project, with the root project first.
      * @throws org.apache.maven.plugin.MojoExecutionException if the super-pom could not be created.
      * @since 1.0-alpha-1
@@ -1149,7 +1149,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     /**
      * Gets the report plugins of a specific project.
      *
-     * @param model                the model to get the report plugins from.
+     * @param model                the model to getModel the report plugins from.
      * @param onlyIncludeInherited <code>true</code> to only return the plugins definitions that will be inherited by
      *                             child projects.
      * @return The map of effective plugin versions keyed by coordinates.

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -140,7 +140,7 @@ public class ResolveRangesMojo extends AbstractVersionsDependencyUpdaterMojo {
      */
     protected void update(ModifiedPomXMLEventReader pom)
             throws MojoExecutionException, MojoFailureException, XMLStreamException, VersionRetrievalException {
-        // Note we have to get the dependencies from the model because the dependencies in the
+        // Note we have to getModel the dependencies from the model because the dependencies in the
         // project may have already had their range resolved [MNG-4138]
         if (hasDependencyManagement()
                 && hasDependenciesInDependencyManagement()

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -22,27 +22,46 @@ package org.codehaus.mojo.versions;
 import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.ModelBase;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.mojo.versions.api.ArtifactVersions;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.VersionRetrievalException;
 import org.codehaus.mojo.versions.api.recording.ChangeRecord;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.codehaus.mojo.versions.utils.DependencyComparator;
+import org.codehaus.mojo.versions.utils.ModelNode;
+import org.codehaus.plexus.util.FileUtils;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
+import static org.codehaus.mojo.versions.api.recording.ChangeRecord.ChangeKind.DEPENDENCY;
+import static org.codehaus.mojo.versions.api.recording.ChangeRecord.ChangeKind.DEPENDENCY_MANAGEMENT;
+import static org.codehaus.mojo.versions.api.recording.ChangeRecord.ChangeKind.PARENT;
 
 /**
  * Updates a dependency to a specific version.
@@ -52,7 +71,7 @@ import static java.util.Collections.singletonList;
  * @author Dan Arcari
  * @since 2.3
  */
-@Mojo(name = "use-dep-version", threadSafe = true)
+@Mojo(name = "use-dep-version", aggregator = true, threadSafe = true)
 public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
 
     /**
@@ -62,11 +81,27 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
     protected String depVersion;
 
     /**
-     * If set to true, will use whatever version is supplied without attempting to validate that such a version is
-     * obtainable from the repository chain.
+     * If set to {@code true}, will use whatever version is supplied without attempting to validate that such
+     * a version is obtainable from the repository chain.
      */
     @Parameter(property = "forceVersion", defaultValue = "false")
     protected boolean forceVersion;
+
+    /**
+     * <p>Will augment normal processing by, if a dependency value is set using a property, trying to update
+     * the value of the property.</p>
+     * <p>If the property value is specified directly, will process it normally (as with {@code processProperties} being
+     * {@code false}. If the property being updated is redefined in the reactor tree, will only change the property
+     * value which lies closest to the dependency being updated. If the same property is also used to set
+     * the value of another dependency, will not update that property value, and log a warning instead.
+     * Finally, if the property value is specified in a parent file which is outside of the project, will log
+     * a message.</p>
+     * <p>Default is {@code false}.</p>
+     *
+     * @since 2.15.0
+     */
+    @Parameter(property = "processProperties", defaultValue = "false")
+    protected boolean processProperties;
 
     @Inject
     public UseDepVersionMojo(
@@ -78,9 +113,8 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
     }
 
     @Override
-    protected void update(ModifiedPomXMLEventReader pom)
-            throws MojoExecutionException, MojoFailureException, XMLStreamException, VersionRetrievalException {
-
+    protected void validateInput() throws MojoExecutionException {
+        super.validateInput();
         if (depVersion == null || depVersion.equals("")) {
             throw new IllegalArgumentException(
                     "depVersion must be supplied with use-specific-version, and cannot be blank.");
@@ -92,57 +126,302 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
                             + "Please specify a value for the 'includes' parameter, "
                             + "or use -DforceVersion=true to override this check.");
         }
+    }
+
+    @Override
+    protected void update(ModifiedPomXMLEventReader pom)
+            throws MojoExecutionException, MojoFailureException, XMLStreamException, VersionRetrievalException {
+        // not used
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        validateInput();
+        List<ModelNode> rawModels;
+        try {
+            ModifiedPomXMLEventReader pomReader = newModifiedPomXER(
+                    new StringBuilder(
+                            new String(Files.readAllBytes(getProject().getFile().toPath()))),
+                    getProject().getFile().toPath().toString());
+            ModelNode rootNode = new ModelNode(PomHelper.getRawModel(pomReader), pomReader);
+            rawModels = PomHelper.getRawModelTree(rootNode, getLog());
+            // reversing to process depth-first
+            Collections.reverse(rawModels);
+        } catch (IOException e) {
+            throw new MojoFailureException(e.getMessage(), e);
+        }
 
         try {
-            if (isProcessingDependencyManagement()) {
-                DependencyManagement dependencyManagement =
-                        PomHelper.getRawModel(getProject()).getDependencyManagement();
-                if (dependencyManagement != null) {
-                    useDepVersion(
-                            pom, dependencyManagement.getDependencies(), ChangeRecord.ChangeKind.DEPENDENCY_MANAGEMENT);
-                }
+            Set<String> propertyBacklog = new HashSet<>();
+            Map<String, Set<Dependency>> propertyConflicts = new HashMap<>();
+            for (ModelNode node : rawModels) {
+                processModel(node, propertyBacklog, propertyConflicts);
             }
-
-            if (getProject().getDependencies() != null && isProcessingDependencies()) {
-                useDepVersion(pom, getProject().getDependencies(), ChangeRecord.ChangeKind.DEPENDENCY);
+            propertyBacklog.forEach(p -> {
+                getLog().warn("Not updating property ${" + p + "}: defined in parent");
+            });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof MojoFailureException) {
+                throw (MojoFailureException) e.getCause();
+            } else if (e.getCause() instanceof MojoExecutionException) {
+                throw (MojoExecutionException) e.getCause();
             }
-
-            if (getProject().getParent() != null && isProcessingParent()) {
-                useDepVersion(pom, singletonList(getParentDependency()), ChangeRecord.ChangeKind.PARENT);
-            }
-        } catch (IOException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
+            throw e;
         }
     }
 
+    /**
+     * Processes a single model and POM file associated with it
+     * @param node tree node to process
+     * @param propertyBacklog a {@link Set} instance used to store dependencies to be updated, but which were not found
+     *                        in the current subtree. These properties need to be carried over to the parent node for
+     *                        processing.
+     * @param propertyConflicts an {@link Map} instance to store properties
+     *                          which are associated with dependencies which do not fit the filter and thus may not
+     *                          be changed. This is then used for conflict detection if a dependency to be changed
+     *                          used one of these properties. Such a change is not allowed and must be reported instead.
+     * @return {@code true} if the file has been changed
+     */
+    protected boolean processModel(
+            ModelNode node, Set<String> propertyBacklog, Map<String, Set<Dependency>> propertyConflicts)
+            throws MojoFailureException, MojoExecutionException {
+        // 1) process the properties carried over from children
+        propertyBacklog.removeIf(p -> updatePropertyValue(node, p));
+
+        // 2) process dependencies and properties from this node
+        try {
+            if (isProcessingDependencyManagement() && node.getModel().getDependencyManagement() != null) {
+                useDepVersion(
+                        node,
+                        node.getModel().getDependencyManagement().getDependencies(),
+                        DEPENDENCY_MANAGEMENT,
+                        propertyBacklog,
+                        propertyConflicts);
+            }
+
+            if (isProcessingDependencies()) {
+                useDepVersion(node, getDependencies(node.getModel()), DEPENDENCY, propertyBacklog, propertyConflicts);
+            }
+
+            if (getProject().getParent() != null && isProcessingParent()) {
+                useDepVersion(node, singletonList(getParentDependency()), PARENT, propertyBacklog, propertyConflicts);
+            }
+        } catch (XMLStreamException e) {
+            throw new MojoFailureException(
+                    "Unable to parse the pom " + node.getModel().getPomFile(), e);
+        } catch (VersionRetrievalException e) {
+            throw new MojoFailureException(
+                    "Unable to retrieve a dependency version while processing "
+                            + node.getModel().getPomFile(),
+                    e);
+        }
+
+        if (node.getModifiedPomXMLEventReader().isModified()) {
+            if (generateBackupPoms) {
+                File backupFile = new File(
+                        node.getModel().getPomFile().getParentFile(),
+                        node.getModel().getPomFile().getName() + ".versionsBackup");
+                if (!backupFile.exists()) {
+                    getLog().debug("Backing up " + node.getModel().getPomFile() + " to " + backupFile);
+                    try {
+                        FileUtils.copyFile(node.getModel().getPomFile(), backupFile);
+                    } catch (IOException e) {
+                        throw new MojoFailureException(
+                                "Error backing up the " + node.getModel().getPomFile(), e);
+                    }
+                } else {
+                    getLog().debug("Leaving existing backup " + backupFile + " unmodified");
+                }
+            } else {
+                getLog().debug("Skipping the generation of a backup file");
+            }
+            try {
+                writeFile(
+                        node.getModel().getPomFile(),
+                        node.getModifiedPomXMLEventReader().asStringBuilder());
+            } catch (IOException e) {
+                throw new MojoFailureException(
+                        "Unable to write the changed file " + node.getModel().getPomFile(), e);
+            }
+        }
+
+        try {
+            saveChangeRecorderResults();
+        } catch (IOException e) {
+            getLog().warn(
+                            "Cannot save the change recorder result for file "
+                                    + node.getModel().getPomFile(),
+                            e);
+        }
+
+        return node.getModifiedPomXMLEventReader().isModified();
+    }
+
+    private static List<Dependency> getDependencies(Model model) {
+        List<Dependency> dependencies = ofNullable(model.getDependencies()).orElse(new ArrayList<>());
+        dependencies.addAll(ofNullable(model.getProfiles())
+                .flatMap(profiles -> profiles.stream()
+                        .map(ModelBase::getDependencies)
+                        .reduce((l1, l2) -> {
+                            l1.addAll(l2);
+                            return l1;
+                        }))
+                .orElse(emptyList()));
+        return dependencies;
+    }
+
+    /**
+     * <p>Will process the given module tree node, updating the {@link ModifiedPomXMLEventReader} associated with the
+     * node if it finds a dependency matching the filter that needs to be changed or, if {@link #processProperties}
+     * is {@code true}, a property value that can be updated.</p>
+     * <p>The method will use the set passed as the {@code backlog} argument to store the properties which it needs
+     * to update, but which were not found in the current tree. These properties need to be carried over to the parent
+     * node for processing.</p>
+     * <p>Similarly, method will use the map passed as the {@code propertyConflicts} argument to store properties
+     * which are associated with dependencies which do not fit the filter and thus may not be changed. This is then
+     * used for conflict detection if a dependency to be changed used one of these properties. Such a change
+     * is not allowed and must be reported instead.</p>
+     *
+     * @param node model tree node to process
+     * @param dependencies collection of dependencies to process (can be taken from dependency management,
+     *                     parent, or dependencies)
+     * @param changeKind {@link ChangeRecord.ChangeKind} instance for the change recorder
+     * @param propertyBacklog a {@link Set} instance used to store dependencies to be updated, but which were not found
+     *                        in the current subtree. These properties need to be carried over to the parent node for
+     *                        processing.
+     * @param propertyConflicts an {@link Map} instance to store properties
+     *                          which are associated with dependencies which do not fit the filter and thus may not
+     *                          be changed. This is then used for conflict detection if a dependency to be changed
+     *                          used one of these properties. Such a change is not allowed and must be reported instead.
+     * @throws MojoExecutionException thrown if a version may not be changed
+     * @throws XMLStreamException thrown if a {@link ModifiedPomXMLEventReader} can't be updated
+     * @throws VersionRetrievalException thrown if dependency versions cannot be retrieved
+     */
     private void useDepVersion(
-            ModifiedPomXMLEventReader pom, Collection<Dependency> dependencies, ChangeRecord.ChangeKind changeKind)
+            ModelNode node,
+            Collection<Dependency> dependencies,
+            ChangeRecord.ChangeKind changeKind,
+            Set<String> propertyBacklog,
+            Map<String, Set<Dependency>> propertyConflicts)
             throws MojoExecutionException, XMLStreamException, VersionRetrievalException {
+        // an additional pass is necessary to collect conflicts if processProperties is enabled
+        if (processProperties) {
+            dependencies.stream()
+                    .filter(dep -> {
+                        try {
+                            return !isIncluded(toArtifact(dep));
+                        } catch (MojoExecutionException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .forEach(dep ->
+                            // if a dependency that is _not_ to be changed is set using a property, register that
+                            // property
+                            // in propertyConflicts; these are the properties that must not be changed
+                            // the list in the value is the list of dependencies that use the said property
+                            PomHelper.extractExpression(dep.getVersion())
+                                    .ifPresent(p -> propertyConflicts.compute(p, (k, v) -> ofNullable(v)
+                                            .map(set -> {
+                                                set.add(dep);
+                                                return set;
+                                            })
+                                            .orElseGet(() -> {
+                                                Set<Dependency> set = new TreeSet<>(DependencyComparator.INSTANCE);
+                                                set.add(dep);
+                                                return set;
+                                            }))));
+        }
+
+        // 2nd pass: check dependencies
         for (Dependency dep : dependencies) {
             if (isExcludeReactor() && isProducedByReactor(dep)) {
-                getLog().info("Ignoring reactor dependency: " + toString(dep));
+                getLog().info("Ignoring a reactor dependency: " + toString(dep));
                 continue;
             }
 
-            if (isHandledByProperty(dep)) {
-                getLog().debug("Ignoring dependency with property as version: " + toString(dep));
+            Optional<String> propertyName = PomHelper.extractExpression(dep.getVersion());
+            if (propertyName.isPresent() && !processProperties) {
+                getLog().info("Ignoring a dependency with the version set using a property: " + toString(dep));
                 continue;
             }
 
-            Artifact artifact = this.toArtifact(dep);
-
+            Artifact artifact = toArtifact(dep);
             if (isIncluded(artifact)) {
                 if (!forceVersion) {
-                    ArtifactVersions versions = getHelper().lookupArtifactVersions(artifact, false);
-
-                    if (!versions.containsVersion(depVersion)) {
+                    if (!getHelper().lookupArtifactVersions(artifact, false).containsVersion(depVersion)) {
                         throw new MojoExecutionException(String.format(
                                 "Version %s is not available for artifact %s:%s",
                                 depVersion, artifact.getGroupId(), artifact.getArtifactId()));
                     }
                 }
-                updateDependencyVersion(pom, dep, depVersion, changeKind);
+                if (!propertyName.isPresent()) {
+                    updateDependencyVersion(node.getModifiedPomXMLEventReader(), dep, depVersion, changeKind);
+                } else {
+                    // propertyName is present
+                    ofNullable(propertyConflicts.get(propertyName.get()))
+                            .map(conflict -> {
+                                getLog().warn("Cannot update property ${" + propertyName.get() + "}: "
+                                        + "controls more than one dependency: "
+                                        + conflict.stream()
+                                                .map(Dependency::getArtifactId)
+                                                .collect(Collectors.joining(", ")));
+                                return false;
+                            })
+                            .orElseGet(() -> {
+                                if (!updatePropertyValue(node, propertyName.get())) {
+                                    propertyBacklog.add(propertyName.get());
+                                } else {
+                                    if (getLog().isDebugEnabled()) {
+                                        getLog().debug(String.format(
+                                                "Updated the %s property value to %s.", dep.getVersion(), depVersion));
+                                    }
+                                }
+                                return true;
+                            });
+                }
             }
         }
+
+        // third pass: if a property is defined at this node, it is not going to conflict with anything from parent
+        propertyConflicts.keySet().removeIf(key -> ofNullable(node.getModel().getProperties())
+                .filter(p -> p.containsKey(key))
+                .isPresent());
+        propertyConflicts.keySet().removeIf(key -> ofNullable(node.getModel().getProfiles())
+                .map(list -> list.stream().anyMatch(p -> ofNullable(p.getProperties())
+                        .filter(prop -> prop.containsKey(key))
+                        .isPresent()))
+                .orElse(false));
+    }
+
+    private boolean updatePropertyValue(ModelNode node, String property) {
+        return ofNullable(node.getModel().getProperties())
+                        .filter(p -> p.containsKey(property))
+                        .map(ignored -> {
+                            try {
+                                return PomHelper.setPropertyVersion(
+                                        node.getModifiedPomXMLEventReader(), null, property, depVersion);
+                            } catch (XMLStreamException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .orElse(false)
+                | ofNullable(node.getModel().getProfiles())
+                        .flatMap(profiles -> profiles.stream()
+                                .map(profile -> ofNullable(profile.getProperties())
+                                        .filter(p -> p.containsKey(property))
+                                        .map(ignored -> {
+                                            try {
+                                                return PomHelper.setPropertyVersion(
+                                                        node.getModifiedPomXMLEventReader(),
+                                                        profile.getId(),
+                                                        property,
+                                                        depVersion);
+                                            } catch (XMLStreamException e) {
+                                                throw new RuntimeException(e);
+                                            }
+                                        })
+                                        .orElse(false))
+                                .reduce(Boolean::logicalOr))
+                        .orElse(false);
     }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent-redefinition/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent-redefinition/child/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>test-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <revision>1.0.1</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent-redefinition/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent-redefinition/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <excludeReactor>false</excludeReactor>
+                    <processProperties>true</processProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent/child/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>test-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/child-parent/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <excludeReactor>false</excludeReactor>
+                    <processProperties>true</processProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation-profiles/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation-profiles/child/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>test-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <revision>1.0.1</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation-profiles/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation-profiles/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>test-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <revision>1.0.0-SNAPSHOT</revision>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>test-group</groupId>
+                    <artifactId>artifactB</artifactId>
+                    <version>${revision}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group:artifactB</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <excludeReactor>false</excludeReactor>
+                    <processProperties>true</processProperties>
+                    <!-- we don't care about artifact resolution here -->
+                    <forceVersion>true</forceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation/child/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>test-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <revision>1.0.1</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-cancellation/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactB</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group:artifactB</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <excludeReactor>false</excludeReactor>
+                    <processProperties>true</processProperties>
+                    <!-- we don't care about artifact resolution here -->
+                    <forceVersion>true</forceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-redefinition/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-redefinition/child/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>test-group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <revision>1.0.1</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-redefinition/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict-redefinition/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactB</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group:artifactA</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <excludeReactor>false</excludeReactor>
+                    <processProperties>true</processProperties>
+                    <!-- we don't care about artifact resolution here -->
+                    <forceVersion>true</forceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/conflict/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>artifactB</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <serverId>serverId</serverId>
+                    <includesList>test-group:artifactA</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <processProperties>true</processProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/simple-profiles/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/simple-profiles/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <profiles>
+        <profile>
+            <id>test-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <revision>1.0.0-SNAPSHOT</revision>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>default-group</groupId>
+                    <artifactId>artifactA</artifactId>
+                    <version>${revision}</version>
+                </dependency>
+            </dependencies>
+
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <serverId>serverId</serverId>
+                    <includesList>default-group</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <processProperties>true</processProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/simple/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/properties/simple/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>default-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${revision}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <serverId>serverId</serverId>
+                    <includesList>default-group</includesList>
+                    <depVersion>2.0.0</depVersion>
+                    <processProperties>true</processProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
- adding a new parameter, processProperties, which will also update property values if dependencies are controlled by properties
- the above parameter will be turned off in order to retain backwards compatibility

The behaviour of the property is described here:

```
/**
 * <p>Will augment normal processing by, if a dependency value is set using a property, trying to update
 * the value of the property.</p>
 * <p>If the property value is specified directly, will process it normally (as with {@code processProperties} being
 * {@code false}. If the property being updated is redefined in the reactor tree, will only change the property
 * value which lies closest to the dependency being updated. If the same property is also used to set
 * the value of another dependency, will not update that property value, and log a warning instead.
 * Finally, if the property value is specified in a parent file which is outside of the project, will log
 * a warning message.</p>
 * <p>Default is {@code false}.</p>
 *
 * @since 2.14.2
 */
```

also, the behaviour is also "described" in the unit tests.

@slawekjaranowski please review

By the way, I've put 2.14.2 tentatively, but because of the nature of this PR, I'd understand if it did not fit into the release.