### PR TITLE
Fixes #896: Fixing available version retrieval; enabling allowSnapshots

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -53,6 +53,7 @@ import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
@@ -184,7 +185,12 @@ public class DefaultVersionsHelper implements VersionsHelper {
                                     mavenSession.getRepositorySession(),
                                     new VersionRangeRequest(
                                             toArtifact(artifact)
-                                                    .setVersion(versionRange != null ? versionRange.toString() : "(,)"),
+                                                    .setVersion(ofNullable(versionRange)
+                                                            .map(VersionRange::getRestrictions)
+                                                            .flatMap(list -> list.stream()
+                                                                    .findFirst()
+                                                                    .map(Restriction::toString))
+                                                            .orElse("(,)")),
                                             usePluginRepositories
                                                     ? mavenSession
                                                             .getCurrentProject()

--- a/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals = ${project.groupId}:${project.artifactId}:2.13.0:display-parent-updates
+invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent2</artifactId>
+    <version>3.1</version>
+    <relativePath/>
+  </parent>
+
+  <artifactId>dummy-test</artifactId>
+  <version>1.0</version>
+
+</project>

--- a/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-no-updates/verify.groovy
@@ -1,0 +1,2 @@
+def output = new File(basedir, "output.txt").text
+assert output =~ /\Qlocalhost:dummy-parent2\E\s*\.*\s*\Q3.1\E\s*$/

--- a/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-parent-updates
+invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent2</artifactId>
+    <version>1.0</version>
+    <relativePath/>
+  </parent>
+
+  <artifactId>dummy-test</artifactId>
+  <version>1.0</version>
+
+</project>

--- a/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-simple-update/verify.groovy
@@ -1,0 +1,2 @@
+def output = new File(basedir, "output.txt").text
+assert output =~ /\Qlocalhost:dummy-parent2\E\s*\.*\s*\Q1.0\E\s+->\s+\Q3.1\E\b/

--- a/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-parent-updates
+invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8 -DallowSnapshots=true

--- a/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>dummy-parent4</artifactId>
+    <version>70</version>
+    <relativePath/>
+  </parent>
+
+  <artifactId>dummy-test</artifactId>
+  <version>1.0</version>
+
+</project>

--- a/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-parent-updates-snapshots/verify.groovy
@@ -1,0 +1,2 @@
+def output = new File(basedir, "output.txt").text
+assert output =~ /\Qlocalhost:dummy-parent4\E\s*\.*\s*\Q70\E\s+->\s+\Q71-SNAPSHOT\E\b/

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -71,26 +69,17 @@ public class DisplayParentUpdatesMojo extends AbstractVersionsDisplayMojo {
         }
 
         String currentVersion = getProject().getParent().getVersion();
-        String version = currentVersion;
-
-        VersionRange versionRange;
-        try {
-            versionRange = VersionRange.createFromVersionSpec(version);
-        } catch (InvalidVersionSpecificationException e) {
-            throw new MojoExecutionException("Invalid version range specification: " + version, e);
-        }
-
         Artifact artifact = getHelper()
                 .createDependencyArtifact(DependencyBuilder.newBuilder()
                         .withGroupId(getProject().getParent().getGroupId())
                         .withArtifactId(getProject().getParent().getArtifactId())
-                        .withVersion(version)
+                        .withVersion(currentVersion)
                         .withType("pom")
                         .build());
 
         ArtifactVersion artifactVersion;
         try {
-            artifactVersion = findLatestVersion(artifact, versionRange, null, false);
+            artifactVersion = findLatestVersion(artifact, null, allowSnapshots, false);
         } catch (VersionRetrievalException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }


### PR DESCRIPTION
- Version range should not be specified in the retrieval at all; removed.
- If provided, the actual version range restriction should be used, and not the result of the toString() method
- Also, allowSnapshots was ignored for the mojo; corrected

@slawekjaranowski please review