### PR TITLE
Resolves #899: Corrected the invocation of Resolver to retrieve the timestamped snapshot version

### DIFF
--- a/versions-maven-plugin/pom.xml
+++ b/versions-maven-plugin/pom.xml
@@ -190,6 +190,14 @@
               ! Not deleting as it might be helpful with assessing performance measurements.
             -->
             <pomExclude>it-property-updates-report-002-slow/*</pomExclude>
+            <!--
+              ! The below test is testing Resolver's resolveVersion being able
+              ! to find a timestamped version of a snapshot. Disabled as it's not using
+              ! the mrm-maven-plugin, and so depends on external artifacts; also:
+              ! it's actually testing Resolver and not the plugin itself.
+              ! It's there for debugging purposes if something goes wrong.
+            -->
+            <pomExclude>it-lock-snapshots-junit/*</pomExclude>
           </pomExcludes>
           <postBuildHookScript>verify</postBuildHookScript>
           <filterProperties>

--- a/versions-maven-plugin/src/it/it-lock-snapshots-junit5/invoker.properties
+++ b/versions-maven-plugin/src/it/it-lock-snapshots-junit5/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:lock-snapshots

--- a/versions-maven-plugin/src/it/it-lock-snapshots-junit5/pom.xml
+++ b/versions-maven-plugin/src/it/it-lock-snapshots-junit5/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-lock-snapshots-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <!-- Can't get mrm-maven-plugin to provide maven-metadata -->
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>5.0-SNAPSHOT</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-lock-snapshots-junit5/verify.groovy
+++ b/versions-maven-plugin/src/it/it-lock-snapshots-junit5/verify.groovy
@@ -1,0 +1,3 @@
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+
+assert !( project.dependencies.dependency.version =~ /-SNAPSHOT/ )

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
@@ -1,0 +1,177 @@
+package org.codehaus.mojo.versions;
+/*
+ * Copyright MojoHaus and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import javax.xml.stream.XMLStreamException;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.testing.stubs.DefaultArtifactHandlerStub;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.codehaus.mojo.versions.utils.MockUtils;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LockSnapshotsMojo}
+ */
+public class LockSnapshotsMojoTest {
+
+    private LockSnapshotsMojo createMojo(RepositorySystem repositorySystem) {
+        return new LockSnapshotsMojo(null, repositorySystem, null, null) {
+            {
+                reactorProjects = emptyList();
+                project = new MavenProject(new Model() {
+                    {
+                        setGroupId("default-group");
+                        setArtifactId("default-project");
+                        setVersion("1.0-SNAPSHOT");
+                    }
+
+                    @Override
+                    public void setDependencies(List<Dependency> dependencies) {
+                        super.setDependencies(singletonList(
+                                DependencyBuilder.dependencyWith("default-group", "default-artifact", "1.0-SNAPSHOT")));
+                    }
+                });
+                session = MockUtils.mockMavenSession();
+            }
+        };
+    }
+
+    private RepositorySystem mockRepositorySystem(UnaryOperator<String> versionProducer)
+            throws VersionResolutionException {
+        RepositorySystem repositorySystem = mock(RepositorySystem.class);
+        when(repositorySystem.resolveVersion(any(), any())).then(i -> {
+            VersionRequest request = i.getArgument(1);
+            return new VersionResult(request)
+                    .setVersion(versionProducer.apply(request.getArtifact().getVersion()));
+        });
+        return repositorySystem;
+    }
+
+    @Test
+    public void testNoTimestampedDependencyFoundNull()
+            throws XMLStreamException, MojoExecutionException, VersionResolutionException {
+        RepositorySystem repositorySystem = mockRepositorySystem(v -> null);
+
+        LockSnapshotsMojo mojo = createMojo(repositorySystem);
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(new RuntimeException("Not supposed to modify the dependency"));
+            mojo.lockSnapshots(null, mojo.project.getDependencies());
+        }
+    }
+
+    @Test
+    public void testNoTimestampedDependencyFoundSameVersion()
+            throws XMLStreamException, MojoExecutionException, VersionResolutionException {
+        RepositorySystem repositorySystem = mockRepositorySystem(UnaryOperator.identity());
+
+        LockSnapshotsMojo mojo = createMojo(repositorySystem);
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(new RuntimeException("Not supposed to modify the dependency"));
+            mojo.lockSnapshots(null, mojo.project.getDependencies());
+        }
+    }
+
+    @Test
+    public void testNoTimestampedParentFoundNull()
+            throws XMLStreamException, MojoExecutionException, VersionResolutionException {
+        RepositorySystem repositorySystem = mockRepositorySystem(v -> null);
+
+        LockSnapshotsMojo mojo = createMojo(repositorySystem);
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setProjectParentVersion(any(), any()))
+                    .thenThrow(new RuntimeException("Not supposed to modify the parent"));
+            mojo.lockParentSnapshot(
+                    null,
+                    new MavenProject(new Model() {
+                        {
+                            setGroupId("default-group");
+                            setArtifactId("default-parent");
+                            setVersion("1.0-SNAPSHOT");
+                        }
+                    }) {
+                        {
+                            setArtifact(new DefaultArtifact(
+                                    "default-group",
+                                    "default-parent",
+                                    "1.0-SNAPSHOT",
+                                    "compile",
+                                    "pom",
+                                    null,
+                                    new DefaultArtifactHandlerStub("jar")));
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testNoTimestampedParentFoundSameVersion()
+            throws XMLStreamException, MojoExecutionException, VersionResolutionException {
+        RepositorySystem repositorySystem = mockRepositorySystem(UnaryOperator.identity());
+
+        LockSnapshotsMojo mojo = createMojo(repositorySystem);
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setProjectParentVersion(any(), any()))
+                    .thenThrow(new RuntimeException("Not supposed to modify the parent"));
+            mojo.lockParentSnapshot(
+                    null,
+                    new MavenProject(new Model() {
+                        {
+                            setGroupId("default-group");
+                            setArtifactId("default-parent");
+                            setVersion("1.0-SNAPSHOT");
+                        }
+                    }) {
+                        {
+                            setArtifact(new DefaultArtifact(
+                                    "default-group",
+                                    "default-parent",
+                                    "1.0-SNAPSHOT",
+                                    "compile",
+                                    "pom",
+                                    null,
+                                    new DefaultArtifactHandlerStub("jar")));
+                        }
+                    });
+        }
+    }
+}


### PR DESCRIPTION

It would be ideal if the Resolver method https://maven.apache.org/resolver/maven-resolver-api/apidocs/org/eclipse/aether/RepositorySystem.html#resolveVersion(org.eclipse.aether.RepositorySystemSession,org.eclipse.aether.resolution.VersionRequest) be tested too, but it's rather a test of the Resolver itself.

Edit: Ah, perhaps the its's simply not supported by mrm: https://github.com/mojohaus/mrm/pull/22
@slawekjaranowski please review