### PR TITLE
Fixes mojohaus#123: add scope filtering

### DIFF
--- a/versions-maven-plugin/src/it/it-compare-dependencies-006/invoker.properties
+++ b/versions-maven-plugin/src/it/it-compare-dependencies-006/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:compare-dependencies -Dscope=compile
+invoker.systemPropertiesFile = test.properties

--- a/versions-maven-plugin/src/it/it-compare-dependencies-006/pom.xml
+++ b/versions-maven-plugin/src/it/it-compare-dependencies-006/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-compare-dependencies-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>#123 add scope filter property</name>
+  <description>
+    the scope filter property to allow excluding artifacts based on scope:
+    junit is set to test scope and we ask a comparison in scope compile
+  </description>
+  <dependencyManagement>
+
+    <dependencies>
+
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>2.0.10</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.0</version>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.1.1-2</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-compare-dependencies-006/test.properties
+++ b/versions-maven-plugin/src/it/it-compare-dependencies-006/test.properties
@@ -1,0 +1,2 @@
+remotePom=localhost:dummy-bom-pom:1.0
+reportOutputFile=target/depDiffs.txt

--- a/versions-maven-plugin/src/it/it-compare-dependencies-006/verify.bsh
+++ b/versions-maven-plugin/src/it/it-compare-dependencies-006/verify.bsh
@@ -1,0 +1,26 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "target/depDiffs.txt" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "2.0.10 -> 2.0.9" ) < 0 )
+    {
+        System.err.println( "Version diff in maven artifact not found. it should be processed because its scope is compile" );
+        return false;
+    }
+    if ( buf.indexOf( "4.0 -> 4.1" ) > 0 )
+    {
+        System.err.println( "Version diff in junit artifact found. it should be excluded because its scope is test" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.PatternIncludesArtifactFilter;
+import org.apache.maven.shared.artifact.filter.ScopeArtifactFilter;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.recording.ChangeRecord;
@@ -105,6 +106,14 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
      */
     @Parameter
     private String[] excludes = null;
+
+    /**
+     * a scope to use to filter the artifacts matching the asked scope (as well as the ones implied by maven)
+     *
+     * @since 2.15
+     */
+    @Parameter(property = "scope")
+    private String scope = null;
 
     /**
      * Whether to process the dependencies section of the project.
@@ -376,6 +385,12 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
             result = result && excludesFilter.include(artifact);
         }
 
+        ArtifactFilter scopeFilter = this.getScopeArtifactFilter();
+
+        if (scopeFilter != null) {
+            result = result && scopeFilter.include(artifact);
+        }
+
         return result;
     }
 
@@ -412,6 +427,13 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
             excludesFilter = new PatternExcludesArtifactFilter(patterns);
         }
         return excludesFilter;
+    }
+
+    private ArtifactFilter getScopeArtifactFilter() {
+        if (scope == null) {
+            return null;
+        }
+        return new ScopeArtifactFilter(scope);
     }
 
     /**


### PR DESCRIPTION

This implements one of the features requested in mojohaus#123 : filtering of artifacts based on their scope.

It adds a scope property to the plugin configuration.
When this is set, only artifacts matching this scope (or ones implied in the maven scope hierarchy) are included.

I made a test for the compare-dependencies goal as it is here that I intend to use it, but it applies to all the goals.
My need it to run comparison only on `compile` dependencies (excluding the tests one that are included in the comparison by default)

(I tried this PR a long time ago as #334 but it went stale and I did not follow up on it at the time)