### PR TITLE
Bump parent from 72 to 73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>72</version>
+    <version>73</version>
   </parent>
 
   <groupId>org.codehaus.mojo.versions</groupId>
@@ -107,7 +107,7 @@
   <scm>
     <connection>scm:git:https://github.com/mojohaus/versions.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mojohaus/versions.git</developerConnection>
-    <tag>2.14.2</tag>
+    <tag>HEAD</tag>
     <url>https://github.com/mojohaus/versions/tree/master</url>
   </scm>
 
@@ -122,10 +122,13 @@
   </ciManagement>
 
   <properties>
-    <mojo.java.target>1.8</mojo.java.target>
-    <maven.compiler.source>${mojo.java.target}</maven.compiler.source>
+    <mojo.java.target>8</mojo.java.target>
+
+    <!-- some of plugins requires JDK 11 -->
+    <recommendedJavaBuildVersion>11</recommendedJavaBuildVersion>
+
     <junitBomVersion>5.9.1</junitBomVersion>
-    <mavenVersion>3.2.5</mavenVersion>
+    <maven.version>3.2.5</maven.version>
     <doxiaVersion>1.12.0</doxiaVersion>
     <doxia-sitetoolsVersion>1.11.1</doxia-sitetoolsVersion>
     <pluginVersion>${project.version}</pluginVersion>
@@ -145,37 +148,37 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-settings</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-compat</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${maven.version}</version>
       </dependency>
 
       <dependency>
@@ -314,17 +317,6 @@
 
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <configLocation>${checkstyle.spotless.config}</configLocation>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <executions>
@@ -377,4 +369,29 @@
     </plugins>
   </reporting>
 
+  <profiles>
+    <profile>
+      <id>java11+</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+
+      <build>
+        <!--- newer versions of plugins requires JDK 11 -->
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+              <configLocation>${checkstyle.spotless.config}</configLocation>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/versions-maven-plugin/pom.xml
+++ b/versions-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <description>The Versions Maven Plugin is used when you want to manage the versions of artifacts in a project's POM.</description>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>${maven.version}</maven>
   </prerequisites>
 
   <dependencies>

--- a/versions-maven-plugin/src/it/it-changerecord-update-parent-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-update-parent-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'parent-update'
     && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-changerecord-update-properties-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-update-properties-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'property-update'
         && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-releases-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-releases-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-snapshots-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-snapshots-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-versions-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-versions-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-changerecord-use-next-versions-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-next-versions-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
 assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'

--- a/versions-maven-plugin/src/it/it-compare-dependencies-issue-289/verify.groovy
+++ b/versions-maven-plugin/src/it/it-compare-dependencies-issue-289/verify.groovy
@@ -1,2 +1,4 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.parent.version == '2.0'

--- a/versions-maven-plugin/src/it/it-force-releases-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-force-releases-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-lock-snapshots-junit/verify.groovy
+++ b/versions-maven-plugin/src/it/it-lock-snapshots-junit/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert !( project.dependencies.dependency.version =~ /-SNAPSHOT/ )

--- a/versions-maven-plugin/src/it/it-unlock-snapshots-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-unlock-snapshots-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-dep-version-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-001/verify.groovy
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import groovy.xml.XmlSlurper
 
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-002/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-002/verify.groovy
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import groovy.xml.XmlSlurper
 
 def parent = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert parent.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-003/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-003/verify.groovy
@@ -17,5 +17,7 @@
  * under the License.
  */
 
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.profiles.profile.dependencies.dependency.version == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-004/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-004/verify.groovy
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import groovy.xml.XmlSlurper
+
 
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.properties.revision == '1.0.1'

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-latest-releases-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-releases-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-latest-snapshots-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-snapshots-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-latest-versions-009/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-versions-009/verify.groovy
@@ -1,2 +1,4 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.parent.version == '3.0'

--- a/versions-maven-plugin/src/it/it-use-latest-versions-010/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-versions-010/verify.groovy
@@ -1,2 +1,4 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.parent.version == '3.0'

--- a/versions-maven-plugin/src/it/it-use-latest-versions-011/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-versions-011/verify.groovy
@@ -1,2 +1,4 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 assert project.parent.version == '1.0.0'

--- a/versions-maven-plugin/src/it/it-use-latest-versions-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-latest-versions-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-next-releases-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-next-releases-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-use-next-snapshots-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-next-snapshots-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper()
         .parse( new File( basedir, 'pom.xml' ) )
 

--- a/versions-maven-plugin/src/it/it-use-releases-issue-134/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-releases-issue-134/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
 
 assert project.dependencyManagement.dependencies.'*'.size() == 1

--- a/versions-maven-plugin/src/it/it-xml-property-updates-report-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-xml-property-updates-report-001/verify.groovy
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def pom = new XmlSlurper()
         .parse( new File( basedir, 'target/property-updates-report.xml' ) )
 


### PR DESCRIPTION
- execute spotless by JDK 11
- add missing import for groovy XmlSlurper in ITs