### PR TITLE
BoundArtifactVersion.toString() to work with NumericVersionComparator

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
@@ -183,4 +183,15 @@ public class BoundArtifactVersion implements ArtifactVersion {
     public void parseVersion(String version) {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Quasi-contract: {@link #toString()} must produce the textual representation of the version, without any
+     * additional items, this is required by the implementation of {@link NumericVersionComparator}.
+     */
+    @Override
+    public String toString() {
+        return comparable.toString();
+    }
 }

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/ordering/VersionComparatorTestBase.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/ordering/VersionComparatorTestBase.java
@@ -19,10 +19,12 @@ package org.codehaus.mojo.versions.ordering;
  */
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.utils.DefaultArtifactVersionCache;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 /**
@@ -86,5 +88,11 @@ public abstract class VersionComparatorTestBase {
     public void testVersionComparatorRow7() {
         assertThat(instance.compare(version("1-alpha-1"), version("2-alpha-1")), lessThan(0));
         assertThat(instance.compare(version("1-alpha-1"), version("1-alpha-2")), lessThan(0));
+    }
+
+    @Test
+    public void testBoundArtifactVersion() {
+        assertThat(
+                instance.compare(new BoundArtifactVersion("1.0.0", Segment.MAJOR), version("1.9.9")), greaterThan(0));
     }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertiesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertiesMojoTest.java
@@ -17,13 +17,16 @@ package org.codehaus.mojo.versions;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
 
 import org.codehaus.mojo.versions.change.DefaultDependencyVersionChange;
+import org.codehaus.mojo.versions.model.RuleSet;
 import org.codehaus.mojo.versions.utils.TestChangeRecorder;
 import org.codehaus.mojo.versions.utils.TestUtils;
 import org.junit.Test;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySystem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
@@ -85,6 +88,26 @@ public class UpdatePropertiesMojoTest extends UpdatePropertiesMojoTestBase {
         //            pomHelperClass.when( () -> PomHelper.setPropertyVersion( any(), anyString(), anyString(),
         // anyString() ) )
         //                            .thenReturn( false );
+        mojo.execute();
+        assertThat(changeRecorder.getChanges(), is(empty()));
+    }
+
+    @Test
+    public void testIssue929() throws Exception {
+        TestUtils.copyDir(Paths.get("src/test/resources/org/codehaus/mojo/update-properties/issue-929"), pomDir);
+        UpdatePropertiesMojo mojo = setUpMojo("update-properties");
+        mojo.allowMajorUpdates = false;
+        mojo.aetherRepositorySystem = mockAetherRepositorySystem(new HashMap<String, String[]>() {
+            {
+                put("artifactA", new String[] {"6.2.5.Final", "8.0.0.Final"});
+            }
+        });
+        mojo.ruleSet = new RuleSet() {
+            {
+                setComparisonMethod("numeric");
+            }
+        };
+
         mojo.execute();
         assertThat(changeRecorder.getChanges(), is(empty()));
     }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-929/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/issue-929/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <artifact-version>6.2.5.Final</artifact-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>default-group</groupId>
+            <artifactId>artifactA</artifactId>
+            <version>${artifact-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
NumericVersionComparator's implementation actually requires all versions to produce the String representation of the version in their #toString method. 

Otherwise numeric comparison will not work properly. Amended BoundArtifactVersion.

@slawekjaranowski @slachiewicz please review
