### PR TITLE
Resolves #931: Fixing problems with encoding in UseDepVersion and PomHelper

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -71,7 +71,6 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.mojo.versions.utils.ModelNode;
 import org.codehaus.mojo.versions.utils.RegexUtils;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -1365,7 +1364,7 @@ public class PomHelper {
                 .map(pomFile -> {
                     try {
                         ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader(
-                                MavenProjectUtils.readFile(pomFile), inputFactory, pomFile.toString());
+                                readXmlFile(pomFile.toFile()), inputFactory, pomFile.toString());
                         return new ModelNode(rootNode, getRawModel(pom), pom);
                     } catch (IOException e) {
                         throw new UncheckedIOException("Could not open " + pomFile, e);

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -71,6 +71,7 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.mojo.versions.utils.ModelNode;
 import org.codehaus.mojo.versions.utils.RegexUtils;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -1364,9 +1365,7 @@ public class PomHelper {
                 .map(pomFile -> {
                     try {
                         ModifiedPomXMLEventReader pom = new ModifiedPomXMLEventReader(
-                                new StringBuilder(new String(Files.readAllBytes(pomFile))),
-                                inputFactory,
-                                pomFile.toString());
+                                MavenProjectUtils.readFile(pomFile), inputFactory, pomFile.toString());
                         return new ModelNode(rootNode, getRawModel(pom), pom);
                     } catch (IOException e) {
                         throw new UncheckedIOException("Could not open " + pomFile, e);

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -18,6 +18,9 @@ package org.codehaus.mojo.versions.utils;
  * under the License.
  */
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -29,6 +32,7 @@ import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.versions.api.VersionRetrievalException;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
@@ -149,5 +153,17 @@ public class MavenProjectUtils {
             }
         }
         return dependency;
+    }
+
+    /**
+     * Reads the given file to a StringBuilder using {@link XmlStreamReader} to determine the file encoding.
+     * @param path file path
+     * @return StringBuilder containing the given file
+     * @throws IOException thrown in case of an I/O error
+     */
+    public static StringBuilder readFile(Path path) throws IOException {
+        try (XmlStreamReader reader = new XmlStreamReader(path.toFile())) {
+            return new StringBuilder(new String(Files.readAllBytes(path), reader.getEncoding()));
+        }
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -18,9 +18,6 @@ package org.codehaus.mojo.versions.utils;
  * under the License.
  */
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -32,7 +29,6 @@ import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.versions.api.VersionRetrievalException;
-import org.codehaus.plexus.util.xml.XmlStreamReader;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
@@ -153,17 +149,5 @@ public class MavenProjectUtils {
             }
         }
         return dependency;
-    }
-
-    /**
-     * Reads the given file to a StringBuilder using {@link XmlStreamReader} to determine the file encoding.
-     * @param path file path
-     * @return StringBuilder containing the given file
-     * @throws IOException thrown in case of an I/O error
-     */
-    public static StringBuilder readFile(Path path) throws IOException {
-        try (XmlStreamReader reader = new XmlStreamReader(path.toFile())) {
-            return new StringBuilder(new String(Files.readAllBytes(path), reader.getEncoding()));
-        }
     }
 }

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dfile.encoding=latin1 -Dincludes=localhost -DdepVersion=1.0.1

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test-group</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>DEVELOP-SNAPSHOT</version>
+
+  <description>Wörter mit Umlauten</description>
+  <!-- Vorläufige Container für Tests -->
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts-iso8859-1/verify.groovy
@@ -1,0 +1,5 @@
+import groovy.xml.XmlSlurper
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.dependencies.dependency.version == '1.0.1'
+assert project.description == 'Wörter mit Umlauten'

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:use-dep-version
+invoker.mavenOpts = -Dfile.encoding=latin1 -Dincludes=localhost -DdepVersion=1.0.1

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test-group</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>DEVELOP-SNAPSHOT</version>
+
+  <description>Wörter mit Umlauten</description>
+  <!-- Vorläufige Container für Tests -->
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-dep-version-issue-931-umlauts/verify.groovy
@@ -1,0 +1,5 @@
+import groovy.xml.XmlSlurper
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.dependencies.dependency.version == '1.0.1'
+assert project.description == 'Wörter mit Umlauten'

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -20,7 +20,6 @@ import javax.xml.stream.XMLStreamException;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,6 +53,7 @@ import org.codehaus.mojo.versions.api.recording.DependencyChangeRecord.ChangeKin
 import org.codehaus.mojo.versions.recording.DefaultPropertyChangeRecord;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
+import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.mojo.versions.utils.ModelNode;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -136,10 +136,10 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         validateInput();
         List<ModelNode> rawModels;
+
         try {
             ModifiedPomXMLEventReader pomReader = newModifiedPomXER(
-                    new StringBuilder(
-                            new String(Files.readAllBytes(getProject().getFile().toPath()))),
+                    MavenProjectUtils.readFile(getProject().getFile().toPath()),
                     getProject().getFile().toPath().toString());
             ModelNode rootNode = new ModelNode(PomHelper.getRawModel(pomReader), pomReader);
             rawModels = PomHelper.getRawModelTree(rootNode, getLog());

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -53,7 +53,6 @@ import org.codehaus.mojo.versions.api.recording.DependencyChangeRecord.ChangeKin
 import org.codehaus.mojo.versions.recording.DefaultPropertyChangeRecord;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
-import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.mojo.versions.utils.ModelNode;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -139,7 +138,7 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
 
         try {
             ModifiedPomXMLEventReader pomReader = newModifiedPomXER(
-                    MavenProjectUtils.readFile(getProject().getFile().toPath()),
+                    PomHelper.readXmlFile(getProject().getFile()),
                     getProject().getFile().toPath().toString());
             ModelNode rootNode = new ModelNode(PomHelper.getRawModel(pomReader), pomReader);
             rawModels = PomHelper.getRawModelTree(rootNode, getLog());


### PR DESCRIPTION
As shown in #931, recent changes introduced in 2.15.0 introduced a regression when the user used irregular characters.

The problem is highly platform dependent and occurs when the `file.encoding` system property does not equal to the one returned by `Charset.defaultCharset()`.

In this particular case, we were using String(byte[]) to construct a String from a byte array which assumed incorrect encoding.

The file was an utf-8 file, but `file.encoding` was equal to `latin1` or `windows1252`. 

@slawekjaranowski please review