### PR TITLE
Remove template param in AbstractVersionsReport

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
@@ -52,7 +52,7 @@ import static org.codehaus.mojo.versions.utils.MiscUtils.filter;
 /**
  * Generates a report of available updates for the dependencies of a project.
  */
-public abstract class AbstractDependencyUpdatesReportMojo extends AbstractVersionsReport<DependencyUpdatesModel> {
+public abstract class AbstractDependencyUpdatesReportMojo extends AbstractVersionsReport {
 
     private static final DependencyComparator DEPENDENCY_COMPARATOR = DependencyComparator.INSTANCE;
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
@@ -46,7 +46,7 @@ import static org.codehaus.mojo.versions.utils.MiscUtils.filter;
 /**
  * Generates a report of available updates for the plugins of a project.
  */
-public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsReport<PluginUpdatesModel> {
+public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsReport {
 
     private static final PluginComparator PLUGIN_COMPARATOR = PluginComparator.INSTANCE;
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReportMojo.java
@@ -45,7 +45,7 @@ import org.codehaus.plexus.i18n.I18N;
  * Generates a report of available updates for properties of a project which are linked to the dependencies and/or
  * plugins of a project.
  */
-public abstract class AbstractPropertyUpdatesReportMojo extends AbstractVersionsReport<PropertyUpdatesModel> {
+public abstract class AbstractPropertyUpdatesReportMojo extends AbstractVersionsReport {
 
     private static final PropertyComparator PROPERTIES_COMPARATOR = PropertyComparator.INSTANCE;
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -43,11 +43,10 @@ import org.codehaus.plexus.i18n.I18N;
 /**
  * Base class for all versions reports.
  *
- * @param <T> modelled report object
  * @author Stephen Connolly
  * @since 1.0-alpha-3
  */
-public abstract class AbstractVersionsReport<T> extends AbstractMavenReport {
+public abstract class AbstractVersionsReport extends AbstractMavenReport {
     /**
      * Internationalization component.
      *

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ParentUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ParentUpdatesReportMojo.java
@@ -47,7 +47,7 @@ import org.codehaus.plexus.i18n.I18N;
  * @since 2.13.0
  */
 @Mojo(name = "parent-updates-report", requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
-public class ParentUpdatesReportMojo extends AbstractVersionsReport<ParentUpdatesModel> {
+public class ParentUpdatesReportMojo extends AbstractVersionsReport {
     @Parameter(defaultValue = "${reactorProjects}", required = true, readonly = true)
     protected List<MavenProject> reactorProjects;
 


### PR DESCRIPTION
- template parameter had been added during a previous refactoring
- however, now it's no longer needed
- removing to keep code clean