### PR TITLE
#299: allowAnyUpdates should be ignored

### DIFF
--- a/versions-test/src/main/java/org/codehaus/mojo/versions/utils/CloseableTempFile.java
+++ b/versions-test/src/main/java/org/codehaus/mojo/versions/utils/CloseableTempFile.java
@@ -1,0 +1,48 @@
+package org.codehaus.mojo.versions.utils;
+
+/*
+ * Copyright MojoHaus and Contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Closeable temporary file
+ */
+public class CloseableTempFile implements AutoCloseable {
+    private final Path path;
+
+    /**
+     * @return path of the temporary file
+     */
+    public Path getPath() {
+        return path;
+    }
+
+    /**
+     * Creates a new temporary file with the given prefix
+     * @param prefix prefix of the temporary file
+     * @throws IOException thrown if file creation fails
+     */
+    public CloseableTempFile(String prefix) throws IOException {
+        path = Files.createTempFile(prefix, ".tmp");
+    }
+
+    @Override
+    public void close() throws Exception {
+        Files.deleteIfExists(path);
+    }
+}


### PR DESCRIPTION
This might be seen as a breaking change, but I think it is in line with what most users expect to happen anyway.

So, this change sanctions these expectations -- allowAnyUpdates shall effectively assume the value of `false` if any of the other modifies are set to `false`.

Actually, this means that it's redundant, but the fact is that it's getting removed in version 3.0 anyway.

@slawekjaranowski what is your opinion?