### PR TITLE
Fix deprecated goals in ITs poms

### DIFF
--- a/versions-enforcer/src/it/it-max-dependency-updates-001/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-001/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>

--- a/versions-enforcer/src/it/it-max-dependency-updates-002/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-002/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>

--- a/versions-enforcer/src/it/it-max-dependency-updates-003/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-003/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>

--- a/versions-enforcer/src/it/it-max-dependency-updates-004/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-004/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>

--- a/versions-enforcer/src/it/it-max-dependency-updates-005/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-005/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>

--- a/versions-enforcer/src/it/it-max-dependency-updates-006/pom.xml
+++ b/versions-enforcer/src/it/it-max-dependency-updates-006/pom.xml
@@ -20,9 +20,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>@maven-enforcer-plugin.version@</version>
-        <goals>
-          <goal>enforce</goal>
-        </goals>
+        <executions>
+          <execution>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <rules>
             <maxDependencyUpdates>


### PR DESCRIPTION
plugin/goals is deprecated in mvn4 was removed
plugin/executions/execution/goals should be used