### PR TITLE
Alter session for version discovery

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -274,6 +274,7 @@ public class DefaultVersionsHelper implements VersionsHelper {
                 repositories = emptyList();
             }
 
+            // in future sessions may become AutoCloseable, so all this would go into try-with-resource block
             DefaultRepositorySystemSession versionDiscoverSession =
                     new DefaultRepositorySystemSession(mavenSession.getRepositorySession());
             versionDiscoverSession.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_ALWAYS);

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -83,6 +83,7 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
@@ -273,11 +274,14 @@ public class DefaultVersionsHelper implements VersionsHelper {
                 repositories = emptyList();
             }
 
+            DefaultRepositorySystemSession versionDiscoverSession =
+                    new DefaultRepositorySystemSession(mavenSession.getRepositorySession());
+            versionDiscoverSession.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_ALWAYS);
             return new ArtifactVersions(
                     artifact,
                     aetherRepositorySystem
                             .resolveVersionRange(
-                                    mavenSession.getRepositorySession(),
+                                    versionDiscoverSession,
                                     new VersionRangeRequest(
                                             toArtifact(artifact)
                                                     .setVersion(ofNullable(versionRange)


### PR DESCRIPTION
Alter session used for discovery, pinpoint ONLY to processed artifact to update ALWAYS. This would fix all the problems reported here https://github.com/mojohaus/versions/issues/959 and here https://issues.apache.org/jira/browse/MRESOLVER-363 just like `-U` does (and people do it by reflex). But this is more correct way, as `-U` is global and refreshes too much.