### PR TITLE
Resolves #973: NPE if actual version is null for a dependency

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -82,11 +82,12 @@ public abstract class AbstractVersionDetails implements VersionDetails {
      * If the artifact is bound by one or more version ranges, returns the restriction that constitutes
      * the version range containing the selected actual version.
      * If there are no version ranges, returns the provided version.
-     * @param selectedVersion actual version used
+     * @param selectedVersion actual version used, may not be {@code null}
      * @return restriction containing the version range selected by the given version,
      * or {@link Optional#empty()} if there are no ranges
      */
     protected Optional<Restriction> getSelectedRestriction(ArtifactVersion selectedVersion) {
+        assert selectedVersion != null;
         return Optional.ofNullable(getCurrentVersionRange())
                 .map(VersionRange::getRestrictions)
                 .flatMap(r -> r.stream()
@@ -116,7 +117,8 @@ public abstract class AbstractVersionDetails implements VersionDetails {
     public Restriction restrictionForUnchangedSegment(
             ArtifactVersion actualVersion, Optional<Segment> unchangedSegment, boolean allowDowngrade)
             throws InvalidSegmentException {
-        Optional<Restriction> selectedRestriction = getSelectedRestriction(actualVersion);
+        Optional<Restriction> selectedRestriction =
+                Optional.ofNullable(actualVersion).flatMap(this::getSelectedRestriction);
         ArtifactVersion selectedRestrictionUpperBound =
                 selectedRestriction.map(Restriction::getUpperBound).orElse(actualVersion);
         ArtifactVersion lowerBound = allowDowngrade

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
@@ -198,21 +199,21 @@ public interface VersionsHelper {
      * Returns a map of all possible updates per dependency. The lookup is done in parallel using
      * {@code LOOKUP_PARALLEL_THREADS} threads.
      *
-     * @param dependencies The set of {@link Dependency} instances to look up.
+     * @param dependencyStream a stream of {@link Dependency} instances to look up.
      * @param usePluginRepositories Search the plugin repositories.
      * @param allowSnapshots whether snapshots should be included
      * @return map containing the ArtifactVersions object per dependency
      * @throws VersionRetrievalException thrown if a version cannot be retrieved
      */
     Map<Dependency, ArtifactVersions> lookupDependenciesUpdates(
-            Set<Dependency> dependencies, boolean usePluginRepositories, boolean allowSnapshots)
+            Stream<Dependency> dependencyStream, boolean usePluginRepositories, boolean allowSnapshots)
             throws VersionRetrievalException;
 
     /**
      * Returns a map of all possible updates per dependency. The lookup is done in parallel using
      * {@code LOOKUP_PARALLEL_THREADS} threads.
      *
-     * @param dependencies The set of {@link Dependency} instances to look up.
+     * @param dependencies stream of {@link Dependency} instances to look up.
      * @param usePluginRepositories Search the plugin repositories.
      * @param useProjectRepositories whether to use regular project repositories
      * @param allowSnapshots whether snapshots should be included
@@ -220,7 +221,7 @@ public interface VersionsHelper {
      * @throws VersionRetrievalException thrown if a version cannot be retrieved
      */
     Map<Dependency, ArtifactVersions> lookupDependenciesUpdates(
-            Set<Dependency> dependencies,
+            Stream<Dependency> dependencies,
             boolean usePluginRepositories,
             boolean useProjectRepositories,
             boolean allowSnapshots)
@@ -247,13 +248,13 @@ public interface VersionsHelper {
     /**
      * Looks up the updates for a set of plugins.
      *
-     * @param plugins The set of {@link Plugin} instances to look up.
+     * @param plugins A stream of {@link Plugin} instances to look up.
      * @param allowSnapshots Include snapshots in the list of updates.
      * @return A map, keyed by plugin, with values of type {@link org.codehaus.mojo.versions.api.PluginUpdatesDetails}.
      * @throws VersionRetrievalException thrown if version resolution fails
      * @since 1.0-beta-1
      */
-    Map<Plugin, PluginUpdatesDetails> lookupPluginsUpdates(Set<Plugin> plugins, boolean allowSnapshots)
+    Map<Plugin, PluginUpdatesDetails> lookupPluginsUpdates(Stream<Plugin> plugins, boolean allowSnapshots)
             throws VersionRetrievalException;
 
     /**

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/AbstractVersionDetailsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/AbstractVersionDetailsTest.java
@@ -30,6 +30,7 @@ import static org.codehaus.mojo.versions.api.Segment.MAJOR;
 import static org.codehaus.mojo.versions.utils.ArtifactVersionUtils.version;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link AbstractVersionDetails}
@@ -155,5 +156,25 @@ public class AbstractVersionDetailsTest {
                 instance.restrictionForUnchangedSegment(version("1.0.1"), empty(), false)
                         .containsVersion(version("2.0.0-1")),
                 is(true));
+    }
+
+    @Test
+    public void testRestrictionForUnchangedSegmentWithoutVersionInformation()
+            throws InvalidSegmentException, InvalidVersionSpecificationException {
+        instance.setCurrentVersionRange(VersionRange.createFromVersionSpec("[,0]"));
+        assertThat(
+                instance.restrictionForUnchangedSegment(null, empty(), false).containsVersion(version("1.0.0")),
+                is(true));
+    }
+
+    @Test
+    public void testGetSelectedRestrictionForNoVersion()
+            throws InvalidVersionSpecificationException, InvalidSegmentException {
+        instance.setCurrentVersionRange(VersionRange.createFromVersionSpec("[,0]"));
+        try {
+            instance.getSelectedRestriction(null);
+            fail("Expected a NullPointerException to be thrown or assertions are not enabled.");
+        } catch (AssertionError ignored) {
+        }
     }
 }

--- a/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
+++ b/versions-enforcer/src/main/java/org/apache/maven/plugins/enforcer/MaxDependencyUpdates.java
@@ -359,14 +359,15 @@ public class MaxDependencyUpdates implements EnforcerRule2 {
             Optional<Segment> ignoredSegment = ignoreSubIncrementalUpdates
                     ? of(SUBINCREMENTAL)
                     : ignoreIncrementalUpdates ? of(INCREMENTAL) : ignoreMinorUpdates ? of(MINOR) : empty();
-            List<ArtifactVersions> upgradable =
-                    versionsHelper.lookupDependenciesUpdates(dependencies, false, allowSnapshots).values().stream()
-                            .filter(v -> v.getVersions(
-                                                    v.restrictionForIgnoreScope(v.getCurrentVersion(), ignoredSegment),
-                                                    true)
-                                            .length
-                                    > 0)
-                            .collect(Collectors.toList());
+            List<ArtifactVersions> upgradable = versionsHelper
+                    .lookupDependenciesUpdates(
+                            dependencies.stream().filter(d -> d.getVersion() != null), false, allowSnapshots)
+                    .values()
+                    .stream()
+                    .filter(v -> v.getVersions(v.restrictionForIgnoreScope(v.getCurrentVersion(), ignoredSegment), true)
+                                    .length
+                            > 0)
+                    .collect(Collectors.toList());
             if (upgradable.size() > maxUpdates) {
                 throw new EnforcerRuleException("More than " + maxUpdates + " upgradable artifacts detected: "
                         + upgradable.stream()

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
 invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
+invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
 invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
+invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
@@ -7,6 +7,12 @@
   <packaging>pom</packaging>
   <name>display-dependency-updates-from-plugins</name>
 
+  <description>
+    Edge case: the pom.xml will fail when we try executing the actual plugin
+    as it is invalid -- lacks version, which caused an NPE (Issue #973)
+    when executing display-dependency-updates.
+  </description>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
@@ -27,8 +27,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-maven-plugin</artifactId>
           <dependencies>
             <dependency>
               <groupId>localhost</groupId>

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-display-dependency-updates-002</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>display-dependency-updates-from-plugins</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <version>1.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>localhost</groupId>
+          <artifactId>dummy-maven-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>localhost</groupId>
+              <artifactId>dummy-api</artifactId>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/pom.xml
@@ -21,8 +21,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>localhost</groupId>
-          <artifactId>dummy-maven-plugin</artifactId>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
           <dependencies>
             <dependency>
               <groupId>localhost</groupId>

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-973-versionless/verify.groovy
@@ -1,0 +1,4 @@
+def output = new File(basedir, "output.txt").text
+def matcher = output =~ /\Qlocalhost:dummy-api\E.*->\s+\Q3.0\E\b/
+assert matcher.find() : "localhost:dummy-api should have been bumped to version 3.0"
+assert !matcher.find() : "localhost:dummy-api may only appear once in the updates list"

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReportMojo.java
@@ -145,11 +145,16 @@ public abstract class AbstractDependencyUpdatesReportMojo extends AbstractVersio
 
         try {
 
-            Map<Dependency, ArtifactVersions> dependencyUpdates =
-                    getHelper().lookupDependenciesUpdates(dependencies, false, allowSnapshots);
+            Map<Dependency, ArtifactVersions> dependencyUpdates = getHelper()
+                    .lookupDependenciesUpdates(
+                            dependencies.stream().filter(d -> d.getVersion() != null), false, allowSnapshots);
 
             Map<Dependency, ArtifactVersions> dependencyManagementUpdates = processDependencyManagement
-                    ? getHelper().lookupDependenciesUpdates(dependencyManagement, false, allowSnapshots)
+                    ? getHelper()
+                            .lookupDependenciesUpdates(
+                                    dependencyManagement.stream().filter(d -> d.getVersion() != null),
+                                    false,
+                                    allowSnapshots)
                     : emptyMap();
 
             if (onlyUpgradable) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPluginUpdatesReportMojo.java
@@ -126,9 +126,9 @@ public abstract class AbstractPluginUpdatesReportMojo extends AbstractVersionsRe
         try {
 
             Map<Plugin, PluginUpdatesDetails> pluginUpdates =
-                    getHelper().lookupPluginsUpdates(plugins, getAllowSnapshots());
+                    getHelper().lookupPluginsUpdates(plugins.stream(), getAllowSnapshots());
             Map<Plugin, PluginUpdatesDetails> pluginManagementUpdates =
-                    getHelper().lookupPluginsUpdates(pluginManagement, getAllowSnapshots());
+                    getHelper().lookupPluginsUpdates(pluginManagement.stream(), getAllowSnapshots());
 
             if (onlyUpgradable) {
                 pluginUpdates = filter(pluginUpdates, p -> !p.isEmpty(allowSnapshots));

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -399,7 +399,11 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         getLog());
 
                 logUpdates(
-                        getHelper().lookupDependenciesUpdates(dependencyManagement, false, allowSnapshots),
+                        getHelper()
+                                .lookupDependenciesUpdates(
+                                        dependencyManagement.stream().filter(d -> d.getVersion() != null),
+                                        false,
+                                        allowSnapshots),
                         "Dependency Management");
             }
             if (isProcessingDependencies()) {
@@ -408,17 +412,21 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         getHelper()
                                 .lookupDependenciesUpdates(
                                         filterDependencies(
-                                                getProject().getDependencies().stream()
-                                                        .filter(dep -> finalDependencyManagement.stream()
-                                                                .noneMatch(depMan -> dependenciesMatch(dep, depMan)))
-                                                        .collect(
-                                                                () -> new TreeSet<>(DependencyComparator.INSTANCE),
-                                                                Set::add,
-                                                                Set::addAll),
-                                                dependencyIncludes,
-                                                dependencyExcludes,
-                                                "Dependencies",
-                                                getLog()),
+                                                        getProject().getDependencies().stream()
+                                                                .filter(dep -> finalDependencyManagement.stream()
+                                                                        .noneMatch(depMan ->
+                                                                                dependenciesMatch(dep, depMan)))
+                                                                .collect(
+                                                                        () -> new TreeSet<>(
+                                                                                DependencyComparator.INSTANCE),
+                                                                        Set::add,
+                                                                        Set::addAll),
+                                                        dependencyIncludes,
+                                                        dependencyExcludes,
+                                                        "Dependencies",
+                                                        getLog())
+                                                .stream()
+                                                .filter(d -> d.getVersion() != null),
                                         false,
                                         allowSnapshots),
                         "Dependencies");
@@ -428,11 +436,14 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         getHelper()
                                 .lookupDependenciesUpdates(
                                         filterDependencies(
-                                                extractPluginDependenciesFromPluginsInPluginManagement(getProject()),
-                                                pluginManagementDependencyIncludes,
-                                                pluginManagementDependencyExcludes,
-                                                "Plugin Management Dependencies",
-                                                getLog()),
+                                                        extractPluginDependenciesFromPluginsInPluginManagement(
+                                                                getProject()),
+                                                        pluginManagementDependencyIncludes,
+                                                        pluginManagementDependencyExcludes,
+                                                        "Plugin Management Dependencies",
+                                                        getLog())
+                                                .stream()
+                                                .filter(d -> d.getVersion() != null),
                                         false,
                                         allowSnapshots),
                         "pluginManagement of plugins");
@@ -442,11 +453,13 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                         getHelper()
                                 .lookupDependenciesUpdates(
                                         filterDependencies(
-                                                extractDependenciesFromPlugins(getProject()),
-                                                pluginDependencyIncludes,
-                                                pluginDependencyExcludes,
-                                                "Plugin Dependencies",
-                                                getLog()),
+                                                        extractDependenciesFromPlugins(getProject()),
+                                                        pluginDependencyIncludes,
+                                                        pluginDependencyExcludes,
+                                                        "Plugin Dependencies",
+                                                        getLog())
+                                                .stream()
+                                                .filter(d -> d.getVersion() != null),
                                         false,
                                         allowSnapshots),
                         "Plugin Dependencies");

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
@@ -255,7 +255,7 @@ public class DisplayExtensionUpdatesMojo extends AbstractVersionsDisplayMojo {
         }
 
         try {
-            logUpdates(getHelper().lookupDependenciesUpdates(dependencies, true, true, allowSnapshots));
+            logUpdates(getHelper().lookupDependenciesUpdates(dependencies.stream(), true, true, allowSnapshots));
         } catch (VersionRetrievalException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }


### PR DESCRIPTION
In case a dependency version is specified in dependencyManagement, a dependency can be versionless.

Dependency updates goals would then attempt to find an updated version to a versionless dependency, which would fail with an NPE or, if that is prevented, an attempt would have been made to find an update to version specified as [,0], which would be any version.

Preventing both issues.

@slawekjaranowski please review. 