### PR TITLE
Resolves #990: Check prerequisites if required enforcer Maven version is empty

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -51,7 +51,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Model;
@@ -816,7 +815,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     private ArtifactVersion getPrerequisitesMavenVersion(MavenProject pluginProject) {
         return ofNullable(pluginProject.getPrerequisites())
                 .map(Prerequisites::getMaven)
-                .map(DefaultArtifactVersion::new)
+                .map(DefaultArtifactVersionCache::of)
                 .orElse(DefaultArtifactVersionCache.of(DEFAULT_MVN_VERSION));
     }
 

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojoTest.java
@@ -1,0 +1,160 @@
+package org.codehaus.mojo.versions;
+
+/*
+ * Copyright MojoHaus and Contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Prerequisites;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.*;
+import org.codehaus.mojo.versions.utils.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySystem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Contains unit tests for {@link DisplayPluginUpdatesMojo}.
+ *
+ * @author Andrzej Jarmoniuk
+ */
+public class DisplayPluginUpdatesMojoTest extends AbstractMojoTestCase {
+
+    @Rule
+    public MojoRule mojoRule = new MojoRule(this);
+
+    private Path tempDir;
+
+    private Path outputPath;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = TestUtils.createTempDir("display-plugin-updates");
+        outputPath = Files.createTempFile(tempDir, "output", "");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            TestUtils.tearDownTempDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    private static ProjectBuilder mockupProjectBuilder() {
+        Prerequisites prerequisites = new Prerequisites();
+        prerequisites.setMaven("3.6.3");
+        MavenProject mavenProject = mock(MavenProject.class);
+        when(mavenProject.getPrerequisites()).thenReturn(prerequisites);
+        ProjectBuildingResult projectBuildingResult = mock(ProjectBuildingResult.class);
+        when(projectBuildingResult.getProject()).thenReturn(mavenProject);
+        ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
+        try {
+            when(projectBuilder.build(any(Artifact.class), anyBoolean(), any(ProjectBuildingRequest.class)))
+                    .thenReturn(projectBuildingResult);
+        } catch (ProjectBuildingException e) {
+            throw new RuntimeException(e);
+        }
+        return projectBuilder;
+    }
+
+    private DisplayPluginUpdatesMojo createMojo() throws Exception {
+        DisplayPluginUpdatesMojo mojo =
+                (DisplayPluginUpdatesMojo) mojoRule.lookupConfiguredMojo(tempDir.toFile(), "display-plugin-updates");
+        mojo.outputEncoding = UTF_8;
+        mojo.outputFile = outputPath.toFile();
+        mojo.setPluginContext(new HashMap<>());
+        mojo.aetherRepositorySystem = mockAetherRepositorySystem(new HashMap<String, String[]>() {
+            {
+                put("default-plugin", new String[] {"1.0.0"});
+                put("maven-enforcer-plugin", new String[] {"3.0.0"});
+            }
+        });
+        setVariableValueToObject(mojo, "projectBuilder", mockupProjectBuilder());
+        return mojo;
+    }
+
+    @Test
+    public void testNoEnforcer() throws Exception {
+        Files.copy(
+                Paths.get("src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-enforcer.xml"),
+                tempDir.resolve("pom.xml"));
+
+        DisplayPluginUpdatesMojo mojo = createMojo();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(outputPath);
+        assertThat(output, hasItem(containsString("Using the minimum version of Maven: 3.3.9")));
+    }
+
+    @Test
+    public void testNoPrerequisites() throws Exception {
+        Files.copy(
+                Paths.get("src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-prerequisites.xml"),
+                tempDir.resolve("pom.xml"));
+
+        DisplayPluginUpdatesMojo mojo = createMojo();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(outputPath);
+        assertThat(output, hasItem(containsString("Using the minimum version of Maven: 3.3.9")));
+    }
+
+    @Test
+    public void testPrerequisitesGreaterThanEnforcer() throws Exception {
+        Files.copy(
+                Paths.get(
+                        "src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-greater.xml"),
+                tempDir.resolve("pom.xml"));
+
+        DisplayPluginUpdatesMojo mojo = createMojo();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(outputPath);
+        assertThat(output, hasItem(containsString("Using the minimum version of Maven: 3.3.9")));
+    }
+
+    @Test
+    public void testPrerequisitesLesserThanEnforcer() throws Exception {
+        Files.copy(
+                Paths.get(
+                        "src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-lesser.xml"),
+                tempDir.resolve("pom.xml"));
+
+        DisplayPluginUpdatesMojo mojo = createMojo();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(outputPath);
+        assertThat(output, hasItem(containsString("Using the minimum version of Maven: 3.3.9")));
+    }
+}

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/MinimalMavenBuildVersionFinderTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/MinimalMavenBuildVersionFinderTest.java
@@ -1,5 +1,7 @@
 package org.codehaus.mojo.versions;
 
+import java.util.Optional;
+
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.codehaus.mojo.versions.utils.DefaultArtifactVersionCache;
 import org.junit.Test;
@@ -37,5 +39,32 @@ public class MinimalMavenBuildVersionFinderTest {
         assertNull(MinimalMavenBuildVersionFinder.getMinimumVersionFromRange("1.0()"));
         assertNull(MinimalMavenBuildVersionFinder.getMinimumVersionFromRange("()1.0"));
         assertNull(MinimalMavenBuildVersionFinder.getMinimumVersionFromRange("(1.0]"));
+    }
+
+    @Test
+    public void testGetGreatestVersion() {
+        assertEquals(
+                MinimalMavenBuildVersionFinder.getGreatestVersion(
+                        new DefaultArtifactVersion("1"), new DefaultArtifactVersion("2")),
+                Optional.of(new DefaultArtifactVersion("2")));
+        assertEquals(
+                MinimalMavenBuildVersionFinder.getGreatestVersion(
+                        new DefaultArtifactVersion("1"),
+                        new DefaultArtifactVersion("2"),
+                        new DefaultArtifactVersion("3")),
+                Optional.of(new DefaultArtifactVersion("3")));
+        assertEquals(
+                MinimalMavenBuildVersionFinder.getGreatestVersion(
+                        new DefaultArtifactVersion("3"),
+                        new DefaultArtifactVersion("2"),
+                        new DefaultArtifactVersion("1")),
+                Optional.of(new DefaultArtifactVersion("3")));
+        assertEquals(
+                MinimalMavenBuildVersionFinder.getGreatestVersion(
+                        new DefaultArtifactVersion("1"), null, new DefaultArtifactVersion("3")),
+                Optional.of(new DefaultArtifactVersion("3")));
+        assertEquals(
+                MinimalMavenBuildVersionFinder.getGreatestVersion(new DefaultArtifactVersion("1"), null),
+                Optional.of(new DefaultArtifactVersion("1")));
     }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-enforcer.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-enforcer.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright MojoHaus and Contributors
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <prerequisites>
+        <maven>3.3.9</maven>
+    </prerequisites>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>default-group</groupId>
+                <artifactId>default-plugin</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-prerequisites.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/no-prerequisites.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright MojoHaus and Contributors
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>default-group</groupId>
+                <artifactId>default-plugin</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.9</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-greater.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-greater.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright MojoHaus and Contributors
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <prerequisites>
+        <maven>3.3.9</maven>
+    </prerequisites>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>default-group</groupId>
+                <artifactId>default-plugin</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.8</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-lesser.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/issue-990/prerequisites-lesser.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright MojoHaus and Contributors
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0.0</version>
+
+    <prerequisites>
+        <maven>3.3.8</maven>
+    </prerequisites>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>default-group</groupId>
+                <artifactId>default-plugin</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.9</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Check prerequisites if enforcer check for Maven version is not present.

~~Prerequisites are checked after enforcer -- disputable, but at least this keeps the behavior backwards compatible.~~

The plugin will choose the version which is the highest between: default maven version, prerequisites, enforcer.

@slawekjaranowski please check