### PR TITLE
Correct message if the latest version of parent is used for update-parent

### DIFF
--- a/versions-maven-plugin/src/it/it-update-parent-latest-version/invoker.properties
+++ b/versions-maven-plugin/src/it/it-update-parent-latest-version/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:update-parent

--- a/versions-maven-plugin/src/it/it-update-parent-latest-version/pom.xml
+++ b/versions-maven-plugin/src/it/it-update-parent-latest-version/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-parent4</artifactId>
+        <version>70</version>
+    </parent>
+
+    <groupId>localhsot</groupId>
+    <artifactId>issue-670</artifactId>
+    <version>0.31-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+</project>

--- a/versions-maven-plugin/src/it/it-update-parent-latest-version/verify.groovy
+++ b/versions-maven-plugin/src/it/it-update-parent-latest-version/verify.groovy
@@ -1,0 +1,10 @@
+
+import groovy.xml.XmlSlurper
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+assert project.parent.version == '70'
+
+
+def buildLog = new File( basedir, "build.log")
+
+assert buildLog.text.contains( '[INFO] The parent project is the latest version')

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -253,7 +253,12 @@ public class UpdateParentMojo extends AbstractVersionsUpdaterMojo {
             }
         }
 
-        getLog().info("No versions found");
+        if (versions.isEmpty(allowSnapshots)) {
+            getLog().info("No versions found");
+        } else {
+            getLog().info("The parent project is the latest version");
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Displaying `No versions found` can be confusing