### PR TITLE
Resolves #978 - use-releases does not update parent

### DIFF
--- a/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/invoker.properties
+++ b/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:use-releases
+invoker.mavenOpts = -DprocessParent=true

--- a/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/pom.xml
+++ b/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-parent2</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>it-use-releases-issue-978-parent-snapshot</artifactId>
+    <version>1</version>
+    <packaging>pom</packaging>
+
+    <description>Test that parent is updated if it uses a snapshot version</description>
+
+</project>

--- a/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/verify.groovy
+++ b/versions-maven-plugin/src/it/it-use-releases-issue-978-parent-snapshot/verify.groovy
@@ -1,0 +1,5 @@
+import groovy.xml.XmlSlurper
+
+def project = new XmlSlurper().parse( new File( basedir, 'pom.xml' ) )
+
+assert project.parent.version == '3.0'


### PR DESCRIPTION
- added an it testing against a plain (not timestamped) -SNAPSHOT
- added a unit test testing against a timestamped snapshot
- added another comparison for the base version if it exists