### PR TITLE
Execute fail-fast job without ITs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,8 +24,8 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
-      ff-goal: '-P run-its install'         # site use project version for reporting
-      verify-goal: '-P run-its install'     # should be the same as for first build
+      ff-goal: 'install'                # site use project version for reporting, no ITs
+      verify-goal: '-P run-its verify'
 
 #  deploy:
 #    name: Deploy


### PR DESCRIPTION
ITs will be executed in matrix in parallel, so we should have a shorter time for whole build.