### PR TITLE
Fix `includeParent` field value not matching `Parameter#defaultValue`

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -137,7 +137,7 @@ public class DisplayPropertyUpdatesMojo extends AbstractVersionsDisplayMojo {
      * @since 2.14.0
      */
     @Parameter(property = "includeParent", defaultValue = "false")
-    protected boolean includeParent = true;
+    protected boolean includeParent;
 
     // -------------------------- STATIC METHODS --------------------------
 


### PR DESCRIPTION
The field value is overwritten by `Parameter#defaultValue` anyway, but the mismatching initial field value might lead to confusion nonetheless.

Looks like this was an oversight when #817 changed the `defaultValue`.