### PR TITLE
Move `expression: {blah} no value` `System.out` to logs

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/change/AbstractVersionChanger.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/change/AbstractVersionChanger.java
@@ -34,7 +34,7 @@ public abstract class AbstractVersionChanger implements VersionChanger {
 
     private final ModifiedPomXMLEventReader pom;
 
-    private final Log log;
+    protected final Log log;
 
     public AbstractVersionChanger(Model model, ModifiedPomXMLEventReader pom, Log log) {
         this.model = model;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/change/DependencyVersionChanger.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/change/DependencyVersionChanger.java
@@ -42,7 +42,8 @@ public class DependencyVersionChanger extends AbstractVersionChanger {
                 versionChange.getArtifactId(),
                 versionChange.getOldVersion(),
                 versionChange.getNewVersion(),
-                getModel())) {
+                getModel(),
+                log)) {
             info("    Updating dependency " + versionChange.getGroupId() + ":" + versionChange.getArtifactId());
             info("        from version " + versionChange.getOldVersion() + " to " + versionChange.getNewVersion());
         }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -561,7 +561,8 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
                 dep.getArtifactId(),
                 dep.getVersion(),
                 newVersion,
-                getProject().getModel())) {
+                getProject().getModel(),
+                getLog())) {
             if (getLog().isInfoEnabled()) {
                 getLog().info("Updated " + toString(dep) + " to version " + newVersion);
             }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
@@ -233,9 +233,10 @@ public class DisplayExtensionUpdatesMojo extends AbstractVersionsDisplayMojo {
                                         .orElse(Collections.emptyList())
                                         .stream()
                                         .map(e -> ExtensionBuilder.newBuilder()
-                                                .withGroupId(PomHelper.evaluate(e.getGroupId(), properties))
-                                                .withArtifactId(PomHelper.evaluate(e.getArtifactId(), properties))
-                                                .withVersion(PomHelper.evaluate(e.getVersion(), properties))
+                                                .withGroupId(PomHelper.evaluate(e.getGroupId(), properties, getLog()))
+                                                .withArtifactId(
+                                                        PomHelper.evaluate(e.getArtifactId(), properties, getLog()))
+                                                .withVersion(PomHelper.evaluate(e.getVersion(), properties, getLog()))
                                                 .build()));
                     }
                 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -134,7 +134,8 @@ public class LockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo {
                             dep.getArtifactId(),
                             version,
                             lockedVersion.get(),
-                            getProject().getModel())) {
+                            getProject().getModel(),
+                            getLog())) {
                         getLog().info("Locked " + toString(dep) + " to version " + lockedVersion.get());
                     }
                 } else {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -261,7 +261,8 @@ public class ResolveRangesMojo extends AbstractVersionsDependencyUpdaterMojo {
                                 artifact.getArtifactId(),
                                 dep.getVersion(),
                                 artifactVersion,
-                                getProject().getModel())) {
+                                getProject().getModel(),
+                                getLog())) {
                             getLog().debug("Version set to " + artifactVersion + " for dependency: " + artifact);
                         } else {
                             getLog().debug("Could not find the version tag for dependency " + artifact + " in project "

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
@@ -129,7 +129,8 @@ public class UnlockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo {
                         dep.getArtifactId(),
                         dep.getVersion(),
                         unlockedVersion,
-                        getProject().getModel())) {
+                        getProject().getModel(),
+                        getLog())) {
 
                     getChangeRecorder()
                             .recordChange(DefaultDependencyChangeRecord.builder()

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
@@ -110,7 +110,8 @@ public class UseReactorMojo extends AbstractVersionsDependencyUpdaterMojo {
                             dep.getArtifactId(),
                             dep.getVersion(),
                             project.getVersion(),
-                            getProject().getModel())) {
+                            getProject().getModel(),
+                            getLog())) {
                         getLog().info("Updated " + toString(dep) + " to version " + project.getVersion());
                     }
                     break;

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/ForceReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/ForceReleasesMojoTest.java
@@ -118,7 +118,7 @@ public class ForceReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -145,7 +145,7 @@ public class ForceReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -172,7 +172,7 @@ public class ForceReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -201,7 +201,7 @@ public class ForceReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
@@ -89,7 +89,7 @@ public class LockSnapshotsMojoTest {
         LockSnapshotsMojo mojo = createMojo(repositorySystem);
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenThrow(new RuntimeException("Not supposed to modify the dependency"));
             mojo.lockSnapshots(null, mojo.project.getDependencies());
         }
@@ -103,7 +103,7 @@ public class LockSnapshotsMojoTest {
         LockSnapshotsMojo mojo = createMojo(repositorySystem);
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenThrow(new RuntimeException("Not supposed to modify the dependency"));
             mojo.lockSnapshots(null, mojo.project.getDependencies());
         }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestReleasesMojoTest.java
@@ -106,7 +106,7 @@ public class UseLatestReleasesMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -135,7 +135,7 @@ public class UseLatestReleasesMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -167,7 +167,7 @@ public class UseLatestReleasesMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
@@ -129,7 +129,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -157,7 +157,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -181,7 +181,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -208,7 +208,7 @@ public class UseLatestVersionsMojoTest {
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
                     .thenReturn(mojo.getProject().getModel());
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -242,7 +242,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -283,7 +283,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -304,7 +304,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -327,7 +327,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }
@@ -353,7 +353,7 @@ public class UseLatestVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             mojo.update(null);
         }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
@@ -93,7 +93,7 @@ public class UseNextReleasesMojoTest {
     public void testNoNewerReleases() {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -114,7 +114,7 @@ public class UseNextReleasesMojoTest {
         }));
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -147,7 +147,7 @@ public class UseNextReleasesMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -179,7 +179,7 @@ public class UseNextReleasesMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
@@ -99,7 +99,7 @@ public class UseNextVersionsMojoTest {
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -120,7 +120,7 @@ public class UseNextVersionsMojoTest {
         }));
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
-                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any()))
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -154,7 +154,7 @@ public class UseNextVersionsMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -186,7 +186,7 @@ public class UseNextVersionsMojoTest {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseReleasesMojoTest.java
@@ -161,7 +161,7 @@ public class UseReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
@@ -190,7 +190,7 @@ public class UseReleasesMojoTest extends AbstractMojoTestCase {
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
                     .when(() -> PomHelper.setDependencyVersion(
-                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class)))
+                            any(), anyString(), anyString(), anyString(), anyString(), any(Model.class), any()))
                     .thenReturn(true);
             pomHelper
                     .when(() -> PomHelper.getRawModel(any(MavenProject.class)))


### PR DESCRIPTION
When running the `versions:set` goal, the console is full of `expression: {blah} no value` messages.

Further investigation identified this occurs when a `pom` contains a property declared in a parent `pom`.

In `PomHelper#getRawModel`:
https://github.com/mojohaus/versions/blob/be0e260a1b45b713ccc1bd09bd93908468c98df4/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java#L127

As such the parent properties are no longer accessible downstream.

Based on this, being unable to evaluate an expression is not unexpected and does not need to appear in any non-`debug` log.

This can be reproduced with a parent:
```
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                      http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.me</groupId>
    <artifactId>parent</artifactId>
    <packaging>pom</packaging>
    <version>0.0.1-SNAPSHOT</version>
    <properties>
        <scala.version>2.13</scala.version>
    </properties>
</project>
```

And root:
```
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                      http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
        <groupId>org.me</groupId>
        <artifactId>parent</artifactId> 
        <version>0.0.1-SNAPSHOT</version>
        <relativePath>parent/pom.xml</relativePath>
    </parent>
    <artifactId>root</artifactId>
    <packaging>pom</packaging>
    <version>0.0.1-SNAPSHOT</version>
    <modules>
        <module>parent</module>
    </modules>
    <properties>
        <generateBackupPoms>false</generateBackupPoms>
        <newVersion>123</newVersion>
    </properties>
    <dependencies>
        <dependency>
            <groupId>org.apache.kafka</groupId>
            <artifactId>kafka_${scala.version}</artifactId>
            <version>3.6.1</version>
        </dependency>
    </dependencies>
</project>
```