### PR TITLE
Refactor - Remove redundant `InputStreamReader`

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -140,7 +141,7 @@ public final class PomHelper {
      * @throws IOException if the file is not found or if the file does not parse.
      */
     public static Model getRawModel(File moduleProjectFile) throws IOException {
-        try (Reader reader = Files.newBufferedReader(moduleProjectFile.toPath())) {
+        try (Reader reader = Files.newBufferedReader(moduleProjectFile.toPath(), Charset.defaultCharset())) {
             Model result = getRawModel(reader);
             result.setPomFile(moduleProjectFile);
             return result;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -23,10 +23,8 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
@@ -142,8 +140,7 @@ public final class PomHelper {
      * @throws IOException if the file is not found or if the file does not parse.
      */
     public static Model getRawModel(File moduleProjectFile) throws IOException {
-        try (Reader reader =
-                new BufferedReader(new InputStreamReader(Files.newInputStream(moduleProjectFile.toPath())))) {
+        try (Reader reader = Files.newBufferedReader(moduleProjectFile.toPath())) {
             Model result = getRawModel(reader);
             result.setPomFile(moduleProjectFile);
             return result;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/CoreExtensionUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/CoreExtensionUtils.java
@@ -18,6 +18,7 @@ package org.codehaus.mojo.versions.utils;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -50,7 +51,7 @@ public final class CoreExtensionUtils {
             return Stream.empty();
         }
 
-        try (Reader reader = Files.newBufferedReader(extensionsFile)) {
+        try (Reader reader = Files.newBufferedReader(extensionsFile, Charset.defaultCharset())) {
             return new CoreExtensionsXpp3Reader()
                     .read(reader).getExtensions().stream().map(ex -> ExtensionBuilder.newBuilder()
                             .withGroupId(ex.getGroupId())

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/CoreExtensionUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/CoreExtensionUtils.java
@@ -16,9 +16,7 @@ package org.codehaus.mojo.versions.utils;
  * limitations under the License.
  */
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,7 +50,7 @@ public final class CoreExtensionUtils {
             return Stream.empty();
         }
 
-        try (Reader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(extensionsFile)))) {
+        try (Reader reader = Files.newBufferedReader(extensionsFile)) {
             return new CoreExtensionsXpp3Reader()
                     .read(reader).getExtensions().stream().map(ex -> ExtensionBuilder.newBuilder()
                             .withGroupId(ex.getGroupId())


### PR DESCRIPTION
Rather than converting `Files.newInputStream` to a `BufferedReader` via an intermediate `InputStreamReader`, `Files.newBufferedReader` can be used instead.

This _currently_ works the same internally in the JRE.