### PR TITLE
Improve speed of versions:resolve-ranges in case parents contain many version properties

### DIFF
--- a/versions-maven-plugin/src/it-repo/it-resolve-ranges-issue-1121-parent.pom
+++ b/versions-maven-plugin/src/it-repo/it-resolve-ranges-issue-1121-parent.pom
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-resolve-ranges-issue-1121-parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <dummy.api.version>1.1.1</dummy.api.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>${dummy.api.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/invoker.properties
+++ b/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-X ${project.groupId}:${project.artifactId}:${project.version}:resolve-ranges

--- a/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/pom.xml
+++ b/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>it-resolve-ranges-issue-1121-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>it-resolve-ranges-issues-1121</artifactId>
+  <packaging>pom</packaging>
+  <name>resolve-ranges IT issue 1121</name>
+
+  <description>Test that resolve-ranges recognizes a property that overrides a property in its parent that is used as a version itself</description>
+
+  <properties>
+    <dummy.api.version>[1,3.0)</dummy.api.version>
+  </properties>
+</project>

--- a/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/verify.bsh
+++ b/versions-maven-plugin/src/it/it-resolve-ranges-issue-1121/verify.bsh
@@ -1,0 +1,21 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File file = new File( basedir, "pom.xml" );
+    String buf = FileUtils.fileRead( file, "UTF-8" );
+
+    if ( buf.indexOf( "<dummy.api.version>2.1</dummy.api.version>" ) < 0 ) 
+    {
+        System.err.println( "Version of dummy-api not resolved" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -25,8 +25,10 @@ import javax.xml.stream.XMLStreamException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
@@ -277,6 +279,11 @@ public class ResolveRangesMojo extends AbstractVersionsDependencyUpdaterMojo {
     private void resolvePropertyRanges(ModifiedPomXMLEventReader pom)
             throws XMLStreamException, MojoExecutionException {
 
+        if (includeProperties == null) {
+            Properties originalProperties = getProject().getOriginalModel().getProperties();
+            includeProperties =
+                    originalProperties.stringPropertyNames().stream().collect(Collectors.joining(","));
+        }
         Map<Property, PropertyVersions> propertyVersions = this.getHelper()
                 .getVersionPropertiesMap(VersionsHelper.VersionPropertiesMapRequest.builder()
                         .withMavenProject(getProject())


### PR DESCRIPTION
PR for #1121 

If 'includeProperties' is null, use it to restrict the properties that are considered in the resolve-ranges mojo to those from the current project. Otherwise, user will normally have included only a subset of those.
Also added an it to cover the situation in #367 as this wasn't covered yet and led me to believe at first that setting 'includeParent' to false in the VersionPropertiesMapRequest was enough.