### PR TITLE
Resolves#1066: Fixed a possible NPE in interpolateVersion

### DIFF
--- a/versions-common/src/test/java/org/codehaus/mojo/versions/utils/MavenProjectUtilsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/utils/MavenProjectUtilsTest.java
@@ -1,0 +1,88 @@
+package org.codehaus.mojo.versions.utils;
+
+import java.util.Properties;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.mojo.versions.utils.MavenProjectUtils.interpolateVersion;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.core.Is.is;
+
+public class MavenProjectUtilsTest {
+
+    @Test
+    public void testInterpolateVersion() {
+        Dependency dep = DependencyBuilder.newBuilder()
+                .withGroupId("groupA")
+                .withArtifactId("artifactA")
+                .withVersion("${param}")
+                .build();
+        MavenProject proj = new MavenProject() {
+            {
+                setOriginalModel(new Model() {
+                    {
+                        setProperties(new Properties() {
+                            {
+                                setProperty("param", "1.0.0");
+                            }
+                        });
+                    }
+                });
+            }
+        };
+        Dependency result = interpolateVersion(dep, proj);
+        assertThat(result.getVersion(), is("1.0.0"));
+    }
+
+    @Test
+    public void testImmutability() {
+        Dependency dep = DependencyBuilder.newBuilder()
+                .withGroupId("groupA")
+                .withArtifactId("artifactA")
+                .withVersion("${param}")
+                .build();
+        MavenProject proj = new MavenProject() {
+            {
+                setOriginalModel(new Model() {
+                    {
+                        setProperties(new Properties() {
+                            {
+                                setProperty("param", "1.0.0");
+                            }
+                        });
+                    }
+                });
+            }
+        };
+        assertThat(interpolateVersion(dep, proj), not(sameInstance(dep)));
+    }
+
+    @Test
+    public void testVersionlessDependency() {
+        Dependency dep = DependencyBuilder.newBuilder()
+                .withGroupId("groupA")
+                .withArtifactId("artifactA")
+                .build();
+        MavenProject proj = new MavenProject() {
+            {
+                setOriginalModel(new Model() {
+                    {
+                        setProperties(new Properties() {
+                            {
+                                setProperty("param", "1.0.0");
+                            }
+                        });
+                    }
+                });
+            }
+        };
+        Dependency result = interpolateVersion(dep, proj);
+        assertThat(result.getVersion(), nullValue());
+    }
+}

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
@@ -364,4 +364,15 @@ public class DependencyUpdatesReportMojoTest {
         String output = os.toString();
         assertThat(output, Matchers.stringContainsInOrder("artifactA", "1.0.0", "artifactB", "1.2.3"));
     }
+
+    @Test
+    public void testVersionlessDependency() throws IOException, MavenReportException {
+        OutputStream os = new ByteArrayOutputStream();
+        SinkFactory sinkFactory = new Xhtml5SinkFactory();
+        new TestDependencyUpdatesReportMojo()
+                .withOriginalDependencyManagement(dependencyOf("artifactA", null))
+                .withProcessDependencyManagement(true)
+                .withProcessDependencyManagementTransitive(false)
+                .generate(sinkFactory.createSink(os), sinkFactory, Locale.getDefault());
+    }
 }


### PR DESCRIPTION
There is a possible NPE if a depden… dencyManagement entry has no version.

Added a couple unit tests to interpolateVersion.
interpolateVersion does not mutate the dependency anymore but returns a modified copy if it needs to modify it.