### PR TITLE
Resolves#1169: Clean-up, remove deprecated methods, remove Plexus StringUtils in favour of Apache Commons

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -31,8 +32,6 @@ import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.codehaus.mojo.versions.ordering.VersionComparator;
-
-import static org.apache.commons.lang3.StringUtils.compare;
 
 /**
  * Holds the results of a search for versions of an artifact.
@@ -65,8 +64,8 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
     /**
      * Creates a new {@link ArtifactVersions} instance.
      *
-     * @param artifact The artifact.
-     * @param versions The versions.
+     * @param artifact          The artifact.
+     * @param versions          The versions.
      * @param versionComparator The version comparison rule.
      * @since 1.0-alpha-3
      */
@@ -93,18 +92,13 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
         setCurrentVersionRange(other.getCurrentVersionRange());
     }
 
-    @SuppressWarnings("checkstyle:InnerAssignment")
     public int compareTo(ArtifactVersions that) {
-        int rv;
         return this == that
                 ? 0
-                : that == null || getClass() != that.getClass()
-                        ? 1
-                        : (rv = compare(getGroupId(), that.getGroupId())) != 0
-                                ? rv
-                                : (rv = compare(getArtifactId(), that.getArtifactId())) != 0
-                                        ? rv
-                                        : compare(getVersion(), that.getVersion());
+                : Comparator.nullsLast(Comparator.comparing(ArtifactVersions::getGroupId)
+                                .thenComparing(ArtifactVersions::getArtifactId)
+                                .thenComparing(ArtifactVersions::getVersion))
+                        .compare(this, that);
     }
 
     @Override
@@ -144,7 +138,7 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
      * any qualifiers from range boundaries).
      *
      * @param version the version to check.
-     * @param range the range to check.
+     * @param range   the range to check.
      * @return <code>true</code> if and only if the version is in the range.
      * @since 1.3
      */
@@ -227,9 +221,9 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
      * the method will only count release versions.
      *
      * @param includeSnapshots {@code includeSnapshots} is {@code true}, snapshots will not counted, which means that
-     *      * the method will only count release versions.
+     *                         * the method will only count release versions.
      * @return if {@code includeSnapshots} is {@code true}, returns {@code true} if there are no versions.
-     * if {@code includeSnapshots} is {@code false}, returns {@code true} if there are no releases.
+     *         if {@code includeSnapshots} is {@code false}, returns {@code true} if there are no releases.
      */
     public boolean isEmpty(boolean includeSnapshots) {
         return includeSnapshots

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
@@ -19,13 +19,14 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -126,11 +127,7 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(getArtifact())
-                .append(getVersions(true))
-                .append(getVersionComparator())
-                .toHashCode();
+        return Objects.hash(getArtifact(), Arrays.hashCode(getVersions(true)), getVersionComparator());
     }
 
     /**

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/DefaultVersionsHelper.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.artifact.Artifact;
@@ -84,7 +85,6 @@ import org.codehaus.mojo.versions.utils.RegexUtils;
 import org.codehaus.mojo.versions.utils.VersionsExpressionEvaluator;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.AuthenticationContext;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PluginUpdatesDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PluginUpdatesDetails.java
@@ -19,13 +19,16 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 
 import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
 
 /**
  * Details of a plugin's updates.
@@ -45,6 +48,10 @@ public class PluginUpdatesDetails extends ArtifactVersions {
 
         this.dependencyVersions = dependencyVersions;
         this.includeSnapshots = includeSnapshots;
+    }
+
+    public boolean isIncludeSnapshots() {
+        return includeSnapshots;
     }
 
     public Map<Dependency, ArtifactVersions> getDependencyVersions() {
@@ -84,5 +91,47 @@ public class PluginUpdatesDetails extends ArtifactVersions {
      */
     public boolean isUpdateAvailable() {
         return isArtifactUpdateAvailable() || isDependencyUpdateAvailable();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof PluginUpdatesDetails)) {
+            return false;
+        }
+        PluginUpdatesDetails other = (PluginUpdatesDetails) o;
+        return includeSnapshots == other.includeSnapshots
+                && Objects.equals(dependencyVersions, other.dependencyVersions)
+                && super.equals(o);
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getArtifact())
+                .append(getVersions(true))
+                .append(getVersionComparator())
+                .append(includeSnapshots)
+                .append(dependencyVersions)
+                .toHashCode();
+    }
+
+    // added an arbitrary comparison just to be able to differentiate objects having different includeSnapshots
+    // and dependencyVersions while their super.compareTo() returns 0
+    @SuppressWarnings("checkstyle:InnerAssignment")
+    public int compareTo(PluginUpdatesDetails that) {
+        int r;
+        return (r = super.compareTo(that)) != 0
+                ? r
+                : Comparator.comparing(PluginUpdatesDetails::isIncludeSnapshots)
+                        .thenComparing(p -> ofNullable(p.dependencyVersions)
+                                .map(Map::values)
+                                .map(c -> ofNullable(that.dependencyVersions)
+                                        .map(Map::values)
+                                        .map(c::containsAll)
+                                        .orElse(true))
+                                .orElse(false))
+                        .compare(this, that);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PluginUpdatesDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PluginUpdatesDetails.java
@@ -19,11 +19,11 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
 
@@ -108,13 +108,12 @@ public class PluginUpdatesDetails extends ArtifactVersions {
     }
 
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(getArtifact())
-                .append(getVersions(true))
-                .append(getVersionComparator())
-                .append(includeSnapshots)
-                .append(dependencyVersions)
-                .toHashCode();
+        return Objects.hash(
+                getArtifact(),
+                Arrays.hashCode(getVersions(true)),
+                getVersionComparator(),
+                includeSnapshots,
+                dependencyVersions);
     }
 
     // added an arbitrary comparison just to be able to differentiate objects having different includeSnapshots

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -52,6 +52,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
@@ -76,7 +77,6 @@ import org.codehaus.mojo.versions.utils.RegexUtils;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.codehaus.stax2.XMLInputFactory2;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/AbstractVersionComparator.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions.ordering;
  * under the License.
  */
 
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 
 /**
@@ -35,7 +36,7 @@ public abstract class AbstractVersionComparator implements VersionComparator {
         if (v == null) {
             return 0;
         }
-        if (VersionComparators.isSnapshot(v)) {
+        if (ArtifactUtils.isSnapshot(v.toString())) {
             return innerGetSegmentCount(VersionComparators.stripSnapshot(v));
         }
         return innerGetSegmentCount(v);

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersion.java
@@ -18,12 +18,12 @@ package org.codehaus.mojo.versions.ordering;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.utils.DefaultArtifactVersionCache;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * <p>Represents an <b>immutable</b> artifact version with all segments <em>major</em> to the given segment

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/MavenVersionComparator.java
@@ -19,11 +19,11 @@ package org.codehaus.mojo.versions.ordering;
  * under the License.
  */
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.codehaus.mojo.versions.api.Segment;
 import org.codehaus.mojo.versions.utils.DefaultArtifactVersionCache;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * A comparator which uses Maven's version rules, i.e. 1.3.34 &gt; 1.3.9 but 1.3.4.3.2.34 &lt; 1.3.4.3.2.9.

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparators.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/ordering/VersionComparators.java
@@ -112,10 +112,6 @@ public final class VersionComparators {
         }
     }
 
-    static boolean isSnapshot(ArtifactVersion v) {
-        return v != null && SNAPSHOT_PATTERN.matcher(v.toString()).find();
-    }
-
     static ArtifactVersion stripSnapshot(ArtifactVersion v) {
         final String version = v.toString();
         final Matcher matcher = SNAPSHOT_PATTERN.matcher(version);
@@ -123,17 +119,5 @@ public final class VersionComparators {
             return DefaultArtifactVersionCache.of(version.substring(0, matcher.start(1) - 1));
         }
         return v;
-    }
-
-    static ArtifactVersion copySnapshot(ArtifactVersion source, ArtifactVersion destination) {
-        if (isSnapshot(destination)) {
-            destination = stripSnapshot(destination);
-        }
-        final Matcher matcher = SNAPSHOT_PATTERN.matcher(source.toString());
-        if (matcher.find()) {
-            return DefaultArtifactVersionCache.of(destination.toString() + "-" + matcher.group(0));
-        } else {
-            return DefaultArtifactVersionCache.of(destination.toString() + "-SNAPSHOT");
-        }
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DelegatingContextualLog.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DelegatingContextualLog.java
@@ -19,8 +19,9 @@ package org.codehaus.mojo.versions.utils;
  * under the License.
  */
 
+import java.util.Objects;
+
 import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Created by IntelliJ IDEA.
@@ -46,7 +47,7 @@ public class DelegatingContextualLog implements ContextualLog {
     }
 
     public synchronized void setContext(String context) {
-        if (StringUtils.equals(currentContext, context)) {
+        if (Objects.equals(currentContext, context)) {
             return;
         }
         if (currentContext != null) {

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyBuilder.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyBuilder.java
@@ -127,47 +127,6 @@ public class DependencyBuilder {
     }
 
     /**
-     * Convenience builder method
-     * @param groupId groupId of the dependency
-     * @param artifactId artifactId of the dependency
-     * @param version version of the dependency
-     * @return new instance of {@linkplain Dependency}
-     * @deprecated please use the {@link #newBuilder()} method instead
-     */
-    @Deprecated
-    public static Dependency dependencyWith(String groupId, String artifactId, String version) {
-        return newBuilder()
-                .withGroupId(groupId)
-                .withArtifactId(artifactId)
-                .withVersion(version)
-                .build();
-    }
-
-    /**
-     * Convenience builder method
-     * @param groupId groupId of the dependency
-     * @param artifactId artifactId of the dependency
-     * @param version version of the dependency
-     * @param type type of the dependency
-     * @param classifier classifier of the dependency
-     * @param scope scope of the dependency
-     * @return new instance of {@linkplain Dependency}
-     * @deprecated please use the {@link #newBuilder()} method instead
-     */
-    @Deprecated
-    public static Dependency dependencyWith(
-            String groupId, String artifactId, String version, String type, String classifier, String scope) {
-        return newBuilder()
-                .withGroupId(groupId)
-                .withArtifactId(artifactId)
-                .withVersion(version)
-                .withType(type)
-                .withClassifier(classifier)
-                .withScope(scope)
-                .build();
-    }
-
-    /**
      * Builds the {@linkplain Dependency} instance
      * @return {@linkplain Dependency} instance
      */

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/filtering/DependencyFilterTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/filtering/DependencyFilterTest.java
@@ -39,9 +39,21 @@ class DependencyFilterTest {
     @Nested
     class RemoveFromTest {
         private final Set<Dependency> input = new HashSet<>(asList(
-                DependencyBuilder.dependencyWith("foo", "bar", "1"),
-                DependencyBuilder.dependencyWith("localhost", "my-api", "2"),
-                DependencyBuilder.dependencyWith("localhost", "my-impl", "3")));
+                DependencyBuilder.newBuilder()
+                        .withGroupId("foo")
+                        .withArtifactId("bar")
+                        .withVersion("1")
+                        .build(),
+                DependencyBuilder.newBuilder()
+                        .withGroupId("localhost")
+                        .withArtifactId("my-api")
+                        .withVersion("2")
+                        .build(),
+                DependencyBuilder.newBuilder()
+                        .withGroupId("localhost")
+                        .withArtifactId("my-impl")
+                        .withVersion("3")
+                        .build()));
 
         @Test
         void removesExcludedDepsWithExactMatch() {
@@ -98,9 +110,21 @@ class DependencyFilterTest {
     @Nested
     class RetainingInTest {
         private final Set<Dependency> input = new HashSet<>(asList(
-                DependencyBuilder.dependencyWith("foo", "bar", "1"),
-                DependencyBuilder.dependencyWith("localhost", "my-api", "2"),
-                DependencyBuilder.dependencyWith("localhost", "my-impl", "3")));
+                DependencyBuilder.newBuilder()
+                        .withGroupId("foo")
+                        .withArtifactId("bar")
+                        .withVersion("1")
+                        .build(),
+                DependencyBuilder.newBuilder()
+                        .withGroupId("localhost")
+                        .withArtifactId("my-api")
+                        .withVersion("2")
+                        .build(),
+                DependencyBuilder.newBuilder()
+                        .withGroupId("localhost")
+                        .withArtifactId("my-impl")
+                        .withVersion("3")
+                        .build()));
 
         @Test
         void retainsOnlyDepsWithExactMatch() {

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/filtering/TokenizedMatcherTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/filtering/TokenizedMatcherTest.java
@@ -19,7 +19,14 @@ class TokenizedMatcherTest {
 
         @Test
         void acceptsExactMatch() {
-            Dependency input = DependencyBuilder.dependencyWith("group", "artifact", "1.0", "jar", "tests", "compile");
+            Dependency input = DependencyBuilder.newBuilder()
+                    .withGroupId("group")
+                    .withArtifactId("artifact")
+                    .withVersion("1.0")
+                    .withType("jar")
+                    .withClassifier("tests")
+                    .withScope("compile")
+                    .build();
 
             boolean actual = matcher.test(input);
 
@@ -38,7 +45,14 @@ class TokenizedMatcherTest {
         void rejectsDifferingFields(
                 String group, String artifact, String version, String type, String classifier, String scope) {
 
-            Dependency input = DependencyBuilder.dependencyWith(group, artifact, version, type, classifier, scope);
+            Dependency input = DependencyBuilder.newBuilder()
+                    .withGroupId(group)
+                    .withArtifactId(artifact)
+                    .withVersion(version)
+                    .withType(type)
+                    .withClassifier(classifier)
+                    .withScope(scope)
+                    .build();
 
             boolean actual = matcher.test(input);
 
@@ -51,7 +65,14 @@ class TokenizedMatcherTest {
 
         @Test
         void acceptsWildcards() {
-            Dependency input = DependencyBuilder.dependencyWith("foo", "my-api", "foo", "foo", "foo", "foo");
+            Dependency input = DependencyBuilder.newBuilder()
+                    .withGroupId("foo")
+                    .withArtifactId("my-api")
+                    .withVersion("foo")
+                    .withType("foo")
+                    .withClassifier("foo")
+                    .withScope("foo")
+                    .build();
 
             TokenizedMatcher matcher = TokenizedMatcher.parse("*:my-api");
 

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/utils/SegmentUtilsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/utils/SegmentUtilsTest.java
@@ -18,13 +18,8 @@ package org.codehaus.mojo.versions.utils;
  * under the License.
  */
 
-import java.util.Optional;
-
-import org.apache.maven.plugin.logging.Log;
-import org.codehaus.mojo.versions.api.Segment;
 import org.junit.jupiter.api.Test;
 
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
 import static org.codehaus.mojo.versions.api.Segment.MAJOR;
@@ -53,30 +48,5 @@ class SegmentUtilsTest {
     @Test
     void testMajor() {
         assertThat(determineUnchangedSegment(false, true, true, null), is(of(MAJOR)));
-    }
-
-    @Test
-    void testEmpty() {
-        Optional<Segment> result;
-        boolean allowMinorUpdates = true;
-        boolean allowIncrementalUpdates = true;
-        Log log = null;
-        if (log != null && !allowIncrementalUpdates) {
-            log.info("Assuming allowMinorUpdates false because allowIncrementalUpdates is false.");
-        }
-
-        Optional<Segment> unchangedSegment = allowIncrementalUpdates
-                ? empty()
-                : allowMinorUpdates && allowIncrementalUpdates
-                        ? of(MAJOR)
-                        : allowIncrementalUpdates ? of(MINOR) : of(INCREMENTAL);
-        if (log != null && log.isDebugEnabled()) {
-            log.debug(unchangedSegment
-                            .map(Segment::minorTo)
-                            .map(Segment::toString)
-                            .orElse("ALL") + " version changes allowed");
-        }
-        result = unchangedSegment;
-        assertThat(result, is(empty()));
     }
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -26,6 +26,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,11 +58,12 @@ import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
 import org.codehaus.mojo.versions.model.RuleSet;
 import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.WriterFactory;
 import org.codehaus.stax2.XMLInputFactory2;
 import org.eclipse.aether.RepositorySystem;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
  * Abstract base class for Versions Mojos.
@@ -321,7 +323,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
                     File backupFile = new File(outFile.getParentFile(), outFile.getName() + ".versionsBackup");
                     if (!backupFile.exists()) {
                         getLog().debug("Backing up " + outFile + " to " + backupFile);
-                        FileUtils.copyFile(outFile, backupFile);
+                        Files.copy(outFile.toPath(), backupFile.toPath(), REPLACE_EXISTING);
                     } else {
                         getLog().debug("Leaving existing backup " + backupFile + " unmodified");
                     }
@@ -366,6 +368,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
      * @throws IOException when things go wrong.
      */
     protected final void writeFile(File outFile, StringBuilder input) throws IOException {
+
         try (Writer writer = WriterFactory.newXmlWriter(outFile)) {
             IOUtil.copy(input.toString(), writer);
         }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CommitMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CommitMojo.java
@@ -19,8 +19,9 @@ package org.codehaus.mojo.versions;
  * under the License.
  */
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -28,7 +29,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
 
 /**
  * Removes the initial backup of the pom, thereby accepting the changes.
@@ -47,13 +47,13 @@ public class CommitMojo extends AbstractMojo {
     private MavenProject project;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        File outFile = project.getFile();
-        File backupFile = new File(outFile.getParentFile(), outFile.getName() + ".versionsBackup");
+        Path outFile = project.getFile().toPath();
+        Path backupFile = outFile.getParent().resolve(outFile.getFileName() + ".versionsBackup");
 
-        if (backupFile.exists()) {
+        if (Files.exists(backupFile)) {
             getLog().info("Accepting all changes to " + outFile);
             try {
-                FileUtils.forceDelete(backupFile);
+                Files.delete(backupFile);
             } catch (IOException e) {
                 throw new MojoExecutionException(e.getMessage(), e);
             }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -48,12 +49,10 @@ import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
-import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 
 import static java.util.Collections.emptySet;
 import static java.util.Optional.empty;
-import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;
 import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromDependencyManagement;
 import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromPlugins;
@@ -499,7 +498,7 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
      */
     static void validateGAVList(List<String> gavList, int numSections, String argumentName)
             throws MojoExecutionException {
-        if (gavList != null && gavList.stream().anyMatch(gav -> countMatches(gav, ":") >= numSections)) {
+        if (gavList != null && gavList.stream().anyMatch(gav -> StringUtils.countMatches(gav, ":") >= numSections)) {
             throw new MojoExecutionException(argumentName + " should not contain more than 6 segments");
         }
     }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -55,7 +56,6 @@ import org.codehaus.mojo.versions.utils.DependencyBuilder;
 import org.codehaus.mojo.versions.utils.ExtensionBuilder;
 import org.codehaus.mojo.versions.utils.ModelNode;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.RepositorySystem;
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -785,6 +785,7 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
                     }
                 }
 
+                assert curState != null;
                 pathStack.push(curState);
                 curState = new StackState(curState.path + "/" + elementName);
             } else if (event.isEndElement()) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DynamicVersioningSCMPlugin.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DynamicVersioningSCMPlugin.java
@@ -96,9 +96,12 @@ public class DynamicVersioningSCMPlugin extends AbstractMojo {
     // standard semantic versioning with an optional 'v' prefix
     protected static final Pattern TAG_VERSION_PATTERN = Pattern.compile("refs/tags/(?:v)?((\\d+\\.\\d+\\.\\d+)(.*))");
 
+    // created to mitigate LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE
+    private static final Logger JGIT_LOGGER = Logger.getLogger("org.eclipse.jgit");
+
     public void execute() throws MojoExecutionException {
         // limit JGits excessive logging
-        Logger.getLogger("org.eclipse.jgit").setLevel(Level.INFO);
+        JGIT_LOGGER.setLevel(Level.INFO);
 
         VersionInformation vi;
 
@@ -200,7 +203,7 @@ public class DynamicVersioningSCMPlugin extends AbstractMojo {
     }
 
     protected Optional<VersionInformation> findHighestVersion(List<String> versionTags) {
-        Optional<String> highestVersionString = versionTags.stream().max(this.new VersionComparator());
+        Optional<String> highestVersionString = versionTags.stream().max(new VersionComparator());
 
         return highestVersionString.map(VersionInformation::new);
     }
@@ -230,7 +233,7 @@ public class DynamicVersioningSCMPlugin extends AbstractMojo {
         return vi;
     }
 
-    protected class VersionComparator implements Comparator<String> {
+    protected static class VersionComparator implements Comparator<String> {
 
         @Override
         public int compare(String version1, String version2) {

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
@@ -100,15 +100,14 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo {
 
             List<String> failures = new ArrayList<>();
             if (!isBlank(newTag)) {
-                getLog().info("Updating tag: " + (scm != null && scm.getTag() != null ? scm.getTag() : "(empty)")
-                        + " -> " + newTag);
+                getLog().info("Updating tag: " + (scm.getTag() != null ? scm.getTag() : "(empty)") + " -> " + newTag);
                 if (!PomHelper.setElementValue(pom, "/project/scm", "tag", newTag)) {
                     failures.add("tag: " + newTag);
                 }
             }
             if (!isBlank(connection)) {
                 getLog().info("Updating connection: "
-                        + (scm != null && scm.getConnection() != null ? scm.getConnection() : "(empty)") + " -> "
+                        + (scm.getConnection() != null ? scm.getConnection() : "(empty)") + " -> "
                         + connection);
                 if (!PomHelper.setElementValue(pom, "/project/scm", "connection", connection)) {
                     failures.add("connection: " + connection);
@@ -116,9 +115,7 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo {
             }
             if (!isBlank(developerConnection)) {
                 getLog().info("Updating developerConnection: "
-                        + (scm != null && scm.getDeveloperConnection() != null
-                                ? scm.getDeveloperConnection()
-                                : "(empty)")
+                        + (scm.getDeveloperConnection() != null ? scm.getDeveloperConnection() : "(empty)")
                         + " -> "
                         + developerConnection);
                 if (!PomHelper.setElementValue(pom, "/project/scm", "developerConnection", developerConnection)) {
@@ -126,8 +123,7 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo {
                 }
             }
             if (!isBlank(url)) {
-                getLog().info("Updating url: " + (scm != null && scm.getUrl() != null ? scm.getUrl() : "(empty)")
-                        + " -> " + url);
+                getLog().info("Updating url: " + (scm.getUrl() != null ? scm.getUrl() : "(empty)") + " -> " + url);
                 if (!PomHelper.setElementValue(pom, "/project/scm", "url", url)) {
                     failures.add("url: " + url);
                 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportMojoTest.java
@@ -148,11 +148,18 @@ public class DependencyUpdatesReportMojoTest {
     }
 
     private static Dependency dependencyOf(String artifactId) {
-        return DependencyBuilder.dependencyWith("groupA", artifactId, "1.0.0", "default", "pom", SCOPE_COMPILE);
+        return dependencyOf(artifactId, "1.0.0");
     }
 
     private static Dependency dependencyOf(String artifactId, String version) {
-        return DependencyBuilder.dependencyWith("groupA", artifactId, version, "default", "pom", SCOPE_COMPILE);
+        return DependencyBuilder.newBuilder()
+                .withGroupId("groupA")
+                .withArtifactId(artifactId)
+                .withVersion(version)
+                .withClassifier("default")
+                .withType("pom")
+                .withScope(SCOPE_COMPILE)
+                .build();
     }
 
     @Test
@@ -342,7 +349,7 @@ public class DependencyUpdatesReportMojoTest {
         assertThat(
                 "Did not generate summary correctly",
                 output,
-                containsString("groupA test-artifact 1.1 compile pom default 1.1.0-2 1.1.3 1.3 3.0"));
+                containsString("groupA test-artifact 1.1 compile default pom 1.1.0-2 1.1.3 1.3 3.0"));
     }
 
     @Test

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/LockSnapshotsMojoTest.java
@@ -61,8 +61,11 @@ public class LockSnapshotsMojoTest {
 
                     @Override
                     public void setDependencies(List<Dependency> dependencies) {
-                        super.setDependencies(singletonList(
-                                DependencyBuilder.dependencyWith("default-group", "default-artifact", "1.0-SNAPSHOT")));
+                        super.setDependencies(singletonList(DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("default-artifact")
+                                .withVersion("1.0-SNAPSHOT")
+                                .build()));
                     }
                 });
                 session = MockUtils.mockMavenSession();

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PluginUpdatesXmlRendererTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PluginUpdatesXmlRendererTest.java
@@ -78,7 +78,11 @@ public class PluginUpdatesXmlRendererTest {
                                                 .collect(Collectors.toList()),
                                         new MavenVersionComparator()),
                                 singletonMap(
-                                        DependencyBuilder.dependencyWith("default-group", "artifactB", "1.0.0"),
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("artifactB")
+                                                .withVersion("1.0.0")
+                                                .build(),
                                         new ArtifactVersions(
                                                 artifactOf("default-group", "artifactB", "1.0.0"),
                                                 Stream.of("1.0.0", "1.0.1-SNAPSHOT", "1.1.0-rc1", "2.0.0")

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
@@ -86,24 +86,26 @@ public class UseLatestVersionsMojoTest {
                                         setArtifactId("project-artifact");
                                         setVersion("1.0.0-SNAPSHOT");
 
-                                        setDependencies(Collections.singletonList(DependencyBuilder.dependencyWith(
-                                                "default-group",
-                                                "dependency-artifact",
-                                                "1.1.1-SNAPSHOT",
-                                                "default",
-                                                "pom",
-                                                SCOPE_COMPILE)));
+                                        setDependencies(Collections.singletonList(DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("dependency-artifact")
+                                                .withVersion("1.1.1-SNAPSHOT")
+                                                .withType("pom")
+                                                .withClassifier("default")
+                                                .withScope(SCOPE_COMPILE)
+                                                .build()));
 
                                         setDependencyManagement(new DependencyManagement());
                                         getDependencyManagement()
                                                 .setDependencies(
-                                                        Collections.singletonList(DependencyBuilder.dependencyWith(
-                                                                "default-group",
-                                                                "dependency-artifact",
-                                                                "1.1.1-SNAPSHOT",
-                                                                "default",
-                                                                "pom",
-                                                                SCOPE_COMPILE)));
+                                                        Collections.singletonList(DependencyBuilder.newBuilder()
+                                                                .withGroupId("default-group")
+                                                                .withArtifactId("dependency-artifact")
+                                                                .withVersion("1.1.1-SNAPSHOT")
+                                                                .withType("pom")
+                                                                .withClassifier("default")
+                                                                .withScope(SCOPE_COMPILE)
+                                                                .build()));
                                     }
                                 });
                             }
@@ -152,8 +154,14 @@ public class UseLatestVersionsMojoTest {
 
         mojo.getProject()
                 .getModel()
-                .setDependencies(Collections.singletonList(DependencyBuilder.dependencyWith(
-                        "default-group", "dependency-artifact", "1.1.0-SNAPSHOT", "default", "pom", SCOPE_COMPILE)));
+                .setDependencies(Collections.singletonList(DependencyBuilder.newBuilder()
+                        .withGroupId("default-group")
+                        .withArtifactId("dependency-artifact")
+                        .withVersion("1.1.0-SNAPSHOT")
+                        .withType("pom")
+                        .withClassifier("default")
+                        .withScope(SCOPE_COMPILE)
+                        .build()));
 
         try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
             pomHelper
@@ -259,20 +267,22 @@ public class UseLatestVersionsMojoTest {
         mojo.getProject()
                 .getModel()
                 .setDependencies(Arrays.asList(
-                        DependencyBuilder.dependencyWith(
-                                "default-group",
-                                "dependency-artifact",
-                                "1.1.1-SNAPSHOT",
-                                "default",
-                                "pom",
-                                SCOPE_COMPILE),
-                        DependencyBuilder.dependencyWith(
-                                "default-group",
-                                "poison-artifact",
-                                "1.1.1.1-SNAPSHOT",
-                                "default",
-                                "pom",
-                                SCOPE_COMPILE)));
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("1.1.1-SNAPSHOT")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build(),
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("poison-artifact")
+                                .withVersion("1.1.1.1-SNAPSHOT")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
 
         setVariableValueToObject(mojo, "processDependencies", true);
         setVariableValueToObject(mojo, "allowSnapshots", false);
@@ -318,10 +328,22 @@ public class UseLatestVersionsMojoTest {
         mojo.getProject()
                 .getModel()
                 .setDependencies(Arrays.asList(
-                        DependencyBuilder.dependencyWith(
-                                "default-group", "dependency-artifact", "0.9.0", "default", "pom", SCOPE_COMPILE),
-                        DependencyBuilder.dependencyWith(
-                                "default-group", "other-artifact", "1.0", "default", "pom", SCOPE_COMPILE)));
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("0.9.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build(),
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("other-artifact")
+                                .withVersion("1.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
         setVariableValueToObject(mojo, "processDependencies", true);
         setVariableValueToObject(mojo, "includes", new String[] {"default-group:other-artifact"});
 
@@ -344,10 +366,22 @@ public class UseLatestVersionsMojoTest {
         mojo.getProject()
                 .getModel()
                 .setDependencies(Arrays.asList(
-                        DependencyBuilder.dependencyWith(
-                                "default-group", "dependency-artifact", "0.9.0", "default", "pom", SCOPE_COMPILE),
-                        DependencyBuilder.dependencyWith(
-                                "default-group", "other-artifact", "1.0", "default", "pom", SCOPE_COMPILE)));
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("0.9.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build(),
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("other-artifact")
+                                .withVersion("1.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
         setVariableValueToObject(mojo, "processDependencies", true);
         setVariableValueToObject(mojo, "excludes", new String[] {"default-group:other-artifact"});
 

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
@@ -80,8 +80,14 @@ public class UseNextReleasesMojoTest {
                                 setVersion("1.0.0-SNAPSHOT");
                             }
                         });
-                        setDependencies(Collections.singletonList(DependencyBuilder.dependencyWith(
-                                "default-group", "dependency-artifact", "1.1.0", "default", "pom", SCOPE_COMPILE)));
+                        setDependencies(Collections.singletonList(DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("1.1.0")
+                                .withClassifier("default")
+                                .withType("pom")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
                     }
                 };
             }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.mockStatic;
 public class UseNextVersionsMojoTest {
 
     private UseNextVersionsMojo mojo;
+
     private TestChangeRecorder changeRecorder;
 
     @Before
@@ -80,13 +81,14 @@ public class UseNextVersionsMojoTest {
                                 setVersion("1.0.0-SNAPSHOT");
                             }
                         });
-                        setDependencies(Collections.singletonList(DependencyBuilder.dependencyWith(
-                                "default-group",
-                                "dependency-artifact",
-                                "1.1.0-SNAPSHOT",
-                                "default",
-                                "pom",
-                                SCOPE_COMPILE)));
+                        setDependencies(Collections.singletonList(DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("1.1.0-SNAPSHOT")
+                                .withClassifier("default")
+                                .withType("pom")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
                     }
                 };
             }


### PR DESCRIPTION
Move from Plexus StringUtils to Apache Commons. Improved ArtifactVersions::compareTo and added a stricter one for PluginUpdatesDetails to comfort static code checkers.