### PR TITLE
Fixes #1140 for reports

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyComparator.java
@@ -21,8 +21,9 @@ package org.codehaus.mojo.versions.utils;
 
 import java.util.Comparator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * A comparator used to sort dependencies by group id, artifact id and finally version.
@@ -41,17 +42,15 @@ public enum DependencyComparator implements Comparator<Dependency> {
      */
     @SuppressWarnings("checkstyle:InnerAssignment")
     public int compare(Dependency d1, Dependency d2) {
-        int r;
         return d1 == d2
                 ? 0
-                : d1 == null
-                        ? 1
-                        : d2 == null
-                                ? -1
-                                : (r = StringUtils.compare(d1.getGroupId(), d2.getGroupId())) != 0
-                                        ? r
-                                        : (r = StringUtils.compare(d1.getArtifactId(), d2.getArtifactId())) != 0
-                                                ? r
-                                                : StringUtils.compare(d1.getVersion(), d2.getVersion());
+                : Comparator.nullsLast(Comparator.comparing(Dependency::getGroupId)
+                                .thenComparing(
+                                        dep -> ofNullable(dep.getArtifactId()).orElse(""))
+                                .thenComparing(
+                                        dep -> ofNullable(dep.getClassifier()).orElse(""))
+                                .thenComparing(
+                                        dep -> ofNullable(dep.getVersion()).orElse("")))
+                        .compare(d1, d2);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -33,6 +33,8 @@ import org.codehaus.mojo.versions.api.VersionRetrievalException;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.startsWith;
+import static org.codehaus.mojo.versions.utils.DependencyBuilder.Location.ARTIFACT_ID;
+import static org.codehaus.mojo.versions.utils.DependencyBuilder.Location.VERSION;
 
 /**
  * Utility methods for extracting dependencies from a {@link org.apache.maven.project.MavenProject}
@@ -155,5 +157,13 @@ public class MavenProjectUtils {
                     .orElse(dependency);
         }
         return dependency;
+    }
+
+    /**
+     * @return {@code true} if the version of the dependency is definned locally in the same project
+     */
+    public static boolean dependencyVersionLocalToReactor(Dependency dependency) {
+        return dependency.getLocation(VERSION.toString()).getSource()
+                == dependency.getLocation(ARTIFACT_ID.toString()).getSource();
     }
 }

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/child/pom.xml
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/child/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>localhost</groupId>
+    <artifactId>parent-artifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child-artifact</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/invoker.properties
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:dependency-updates-report -f child/pom.xml
+invoker.mavenOpts = -DdependencyUpdatesReportFormats=xml -DprocessDependencyManagement=false -DprocessDependencyManagementTransitive=false -DonlyProjectDependencies=true -DonlyUpgradable=true -DshowVersionless=false

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/pom.xml
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/pom.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>parent-artifact</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-api</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/verify.groovy
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1140/verify.groovy
@@ -1,0 +1,2 @@
+def output = new File(basedir, "child/target/dependency-updates-report.xml").text
+assert !output.contains("<artifactId>dummy-api</artifactId>")

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-009-processDependencyManagementTransitive-true/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-009-processDependencyManagementTransitive-true/verify.groovy
@@ -1,0 +1,4 @@
+def buildLog = new File( basedir, "build.log").text
+assert buildLog =~ /\Qlocalhost:dummy-api\E\s*\.*\s*1\.1\s+->\s+3\.0/
+assert buildLog =~ /\Qlocalhost:dummy-impl\E\s*\.*\s*1\.2\s+->\s+2\.2/
+assert !(buildLog =~ /\Qlocalhost:dummy-api-impl-bom-pom\E\s*\.*\s*1\.0\s+->\s+2\.0/)

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesAggregateReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesAggregateReport.java
@@ -27,7 +27,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.mojo.versions.reporting.util.AggregateReportUtils;
@@ -71,8 +70,7 @@ public class DependencyUpdatesAggregateReport extends AbstractDependencyUpdatesR
      * {@inheritDoc}
      * */
     @Override
-    protected void populateDependencyManagement(
-            Set<Dependency> dependencyManagementCollector, Set<Dependency> dependencies) throws MavenReportException {
+    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector) {
         for (MavenProject project : AggregateReportUtils.getProjectsToProcess(getProject())) {
             getLog().debug(String.format("Collecting managed dependencies for project %s", project.getName()));
             handleDependencyManagementTransitive(project, dependencyManagementCollector);

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
@@ -28,7 +28,6 @@ import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.plexus.i18n.I18N;
@@ -67,8 +66,7 @@ public class DependencyUpdatesReport extends AbstractDependencyUpdatesReport {
      * {@inheritDoc}
      * */
     @Override
-    protected void populateDependencyManagement(
-            Set<Dependency> dependencyManagementCollector, Set<Dependency> dependencies) throws MavenReportException {
+    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector) {
         if (hasDependencyManagement(getProject())) {
             getLog().debug(String.format(
                     "Collecting managed dependencies for project %s",

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -45,13 +45,12 @@ import org.codehaus.mojo.versions.internal.DependencyUpdatesLoggingHelper;
 import org.codehaus.mojo.versions.internal.DependencyUpdatesLoggingHelper.DependencyUpdatesResult;
 import org.codehaus.mojo.versions.rewriting.MutableXMLStreamReader;
 import org.codehaus.mojo.versions.utils.DependencyComparator;
+import org.codehaus.mojo.versions.utils.MavenProjectUtils;
 import org.codehaus.mojo.versions.utils.SegmentUtils;
 import org.eclipse.aether.RepositorySystem;
 
 import static java.util.Collections.emptySet;
 import static org.codehaus.mojo.versions.filtering.DependencyFilter.filterDependencies;
-import static org.codehaus.mojo.versions.utils.DependencyBuilder.Location.ARTIFACT_ID;
-import static org.codehaus.mojo.versions.utils.DependencyBuilder.Location.VERSION;
 import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromDependencyManagement;
 import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractDependenciesFromPlugins;
 import static org.codehaus.mojo.versions.utils.MavenProjectUtils.extractPluginDependenciesFromPluginsInPluginManagement;
@@ -96,7 +95,7 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
      * report updates on dependencies.</p>
      * <p>Default is {@code false}.</p>
      *
-     * @since 2.18.1
+     * @since 2.19.0
      */
     @Parameter(property = "showVersionless", defaultValue = "true")
     protected boolean showVersionless = true;
@@ -372,14 +371,6 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
     // --------------------- Interface Mojo ---------------------
 
     /**
-     * @return {@code true} if the version of the dependency is definned locally in the same project
-     */
-    private static boolean dependencyVersionLocalToReactor(Dependency dependency) {
-        return dependency.getLocation(VERSION.toString()).getSource()
-                == dependency.getLocation(ARTIFACT_ID.toString()).getSource();
-    }
-
-    /**
      * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
      * @throws org.apache.maven.plugin.MojoFailureException   when things go wrong in a very bad way
      * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#execute()
@@ -421,7 +412,8 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                                                         .noneMatch(depMan ->
                                                                                 dependenciesMatch(dep, depMan)))
                                                                 .filter(dep -> showVersionless
-                                                                        || dependencyVersionLocalToReactor(dep))
+                                                                        || MavenProjectUtils
+                                                                                .dependencyVersionLocalToReactor(dep))
                                                                 .collect(
                                                                         () -> new TreeSet<>(
                                                                                 DependencyComparator.INSTANCE),


### PR DESCRIPTION
I managed to reproduce #1140 for reports, so here is a fix.

Added an integration test + showVersionless for dependency-updates-report.

Added some small refactoring.