### PR TITLE
Fixed #1191: Processes (all) profiles from original model if transitive is false

### DIFF
--- a/versions-maven-plugin/src/it/it-changerecord-update-parent-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-update-parent-001/verify.groovy
@@ -1,8 +1,8 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'parent-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'parent-update'
     && node.@groupId == 'localhost'
     && node.@artifactId == 'dummy-parent'
     && node.@oldVersion == '1.0'
-    && node.@newVersion == '3.0' } != null
+    && node.@newVersion == '3.0' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-changerecord-update-properties-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-update-properties-001/verify.groovy
@@ -1,11 +1,11 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'property-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'property-update'
         && node.@groupId == 'localhost'
         && node.@artifactId == 'dummy-api'
         && node.@oldVersion == '1.0'
-        && node.@newVersion == '3.0' } != null
-assert changes.propertyUpdate.find { node -> node.@property == 'api'
+        && node.@newVersion == '3.0' }.isEmpty())
+assert !(changes.propertyUpdate.find { node -> node.@property == 'api'
         && node.@oldValue == '1.0'
-        && node.@newValue == '3.0' } != null
+        && node.@newValue == '3.0' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-releases-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-releases-001/verify.groovy
@@ -1,8 +1,8 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'
         && node.@artifactId == 'dummy-api'
         && node.@oldVersion == '1.1.1-2'
-        && node.@newVersion == '3.0' } != null
+        && node.@newVersion == '3.0' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-snapshots-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-snapshots-001/verify.groovy
@@ -1,8 +1,8 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'
         && node.@artifactId == 'dummy-api'
         && node.@oldVersion == '1.0'
-        && node.@newVersion == '1.9.1-SNAPSHOT' } != null
+        && node.@newVersion == '1.9.1-SNAPSHOT' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-changerecord-use-latest-versions-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-latest-versions-001/verify.groovy
@@ -1,8 +1,8 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'
         && node.@artifactId == 'dummy-api'
         && node.@oldVersion == '1.1.1-2'
-        && node.@newVersion == '3.0' } != null
+        && node.@newVersion == '3.0' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-changerecord-use-next-versions-001/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-use-next-versions-001/verify.groovy
@@ -1,8 +1,8 @@
 import groovy.xml.XmlSlurper
 
 def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
-assert changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
+assert !(changes.dependencyUpdate.find { node -> node.@kind == 'dependency-update'
         && node.@groupId == 'localhost'
         && node.@artifactId == 'dummy-api'
         && node.@oldVersion == '1.1.1-2'
-        && node.@newVersion == '1.1.2' } != null
+        && node.@newVersion == '1.1.2' }.isEmpty())

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/invoker.properties
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:dependency-updates-report
+invoker.mavenOpts = -DdependencyUpdatesReportFormats=xml -DprocessDependencyManagementTransitive=false

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/pom.xml
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>issue-1191</artifactId>
+  <version>1.0</version>
+
+  <description>display-dependency-updates should consider dependencyManagement in enabled profiles</description>
+
+  <profiles>
+    <profile>
+      <id>test-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>1.0</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
+
+</project>

--- a/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/verify.groovy
+++ b/versions-maven-plugin/src/it/it-dependency-updates-report-issue-1191/verify.groovy
@@ -1,0 +1,8 @@
+import groovy.xml.XmlSlurper
+
+def report = new XmlSlurper().parse(new File(basedir, "target/dependency-updates-report.xml"))
+assert !(report
+        .dependencyManagements
+        .dependencyManagement
+        .find { node -> node.artifactId == 'dummy-api' }.isEmpty())
+

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -347,26 +347,6 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                 || Objects.equals(managedDependency.getVersion(), dependency.getVersion());
     }
 
-    public boolean isProcessingDependencyManagement() {
-        return processDependencyManagement;
-    }
-
-    public boolean isProcessingDependencies() {
-        return processDependencies;
-    }
-
-    public boolean isProcessingPluginDependencies() {
-        return processPluginDependencies;
-    }
-
-    public boolean isProcessPluginDependenciesInDependencyManagement() {
-        return processPluginDependenciesInPluginManagement;
-    }
-
-    public boolean isVerbose() {
-        return verbose;
-    }
-
     // ------------------------ INTERFACE METHODS ------------------------
 
     // --------------------- Interface Mojo ---------------------
@@ -390,10 +370,9 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
         logInit();
         validateInput();
 
-        Set<Dependency> dependencyManagement = emptySet();
-
+        Set<Dependency> dependencyManagement;
         try {
-            if (isProcessingDependencyManagement()) {
+            if (processDependencyManagement) {
                 dependencyManagement = filterDependencies(
                         extractDependenciesFromDependencyManagement(
                                 getProject(), processDependencyManagementTransitive, getLog()),
@@ -409,15 +388,16 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                         false,
                                         allowSnapshots),
                         "Dependency Management");
+            } else {
+                dependencyManagement = emptySet();
             }
-            if (isProcessingDependencies()) {
-                Set<Dependency> finalDependencyManagement = dependencyManagement;
+            if (processDependencies) {
                 logUpdates(
                         getHelper()
                                 .lookupDependenciesUpdates(
                                         filterDependencies(
                                                         getProject().getDependencies().stream()
-                                                                .filter(dep -> finalDependencyManagement.stream()
+                                                                .filter(dep -> dependencyManagement.stream()
                                                                         .noneMatch(depMan ->
                                                                                 dependenciesMatch(dep, depMan)))
                                                                 .filter(dep -> showVersionless
@@ -437,7 +417,7 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                         allowSnapshots),
                         "Dependencies");
             }
-            if (isProcessPluginDependenciesInDependencyManagement()) {
+            if (processPluginDependenciesInPluginManagement) {
                 logUpdates(
                         getHelper()
                                 .lookupDependenciesUpdates(
@@ -454,7 +434,7 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                                         allowSnapshots),
                         "pluginManagement of plugins");
             }
-            if (isProcessingPluginDependencies()) {
+            if (processPluginDependencies) {
                 logUpdates(
                         getHelper()
                                 .lookupDependenciesUpdates(
@@ -513,7 +493,7 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
                 INFO_PAD_SIZE + getOutputLineWidthOffset(),
                 verbose);
 
-        if (isVerbose()) {
+        if (verbose) {
             if (updates.getUsingLatest().isEmpty()) {
                 if (!updates.getWithUpdates().isEmpty()) {
                     logLine(false, "No dependencies in " + section + " are using the newest version.");

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DependencyUpdatesReportTest.java
@@ -372,6 +372,9 @@ public class DependencyUpdatesReportTest {
         assertThat(output, Matchers.stringContainsInOrder("artifactA", "1.0.0", "artifactB", "1.2.3"));
     }
 
+    /*
+     * Possible NPE if dependencyManagement has an entry without a version (issue 1066)
+     */
     @Test
     public void testVersionlessDependency() throws IOException, MavenReportException {
         OutputStream os = new ByteArrayOutputStream();

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/profiles/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/profiles/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>issue-1191</artifactId>
+  <version>1.0</version>
+
+  <description>display-dependency-updates should consider dependencyManagement in enabled profiles</description>
+
+  <profiles>
+    <profile>
+      <id>test-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>1.0.0</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
If processDependencyManagementTransitive is false, will also process dependency management entries from profiles (all profiles). 
This was previously reported as a bug.
