### PR TITLE
Refactoring: coalesce use-*-* goals.

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -228,15 +229,12 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
      * @since 1.0-alpha-3
      */
     protected Artifact findArtifact(Dependency dependency) {
-        if (getProject().getDependencyArtifacts() == null) {
-            return null;
-        }
-        for (Artifact artifact : getProject().getDependencyArtifacts()) {
-            if (compare(artifact, dependency)) {
-                return artifact;
-            }
-        }
-        return null;
+        return Optional.ofNullable(getProject().getDependencyArtifacts())
+                // no mutation, so parallelStream is safe
+                .flatMap(artifacts -> artifacts.parallelStream()
+                        .filter(artifact -> compare(artifact, dependency))
+                        .findAny())
+                .orElse(null);
     }
 
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -123,13 +123,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
     @Parameter(property = "generateBackupPoms", defaultValue = "true")
     protected boolean generateBackupPoms;
 
-    /**
-     * Whether to allow snapshots when searching for the latest version of an artifact.
-     *
-     * @since 1.0-alpha-1
-     */
-    @Parameter(property = "allowSnapshots", defaultValue = "false")
-    protected boolean allowSnapshots;
+    protected abstract boolean isAllowSnapshots();
 
     /**
      * Our versions helper.
@@ -296,7 +290,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
     protected ArtifactVersion findLatestVersion(
             Artifact artifact, VersionRange versionRange, Boolean allowingSnapshots, boolean usePluginRepositories)
             throws MojoExecutionException, VersionRetrievalException {
-        boolean includeSnapshots = allowingSnapshots != null ? allowingSnapshots : this.allowSnapshots;
+        boolean includeSnapshots = allowingSnapshots != null ? allowingSnapshots : isAllowSnapshots();
         final ArtifactVersions artifactVersions =
                 getHelper().lookupArtifactVersions(artifact, versionRange, usePluginRepositories);
         return artifactVersions.getNewestVersion(versionRange, null, includeSnapshots, false);
@@ -437,7 +431,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
         ArtifactVersion winner = version.getNewestVersion(
                 currentVersion,
                 property,
-                this.allowSnapshots,
+                isAllowSnapshots(),
                 this.reactorProjects,
                 this.getHelper(),
                 allowDowngrade,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
@@ -116,6 +116,12 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
     @Parameter(property = "reportOutputFile")
     protected File reportOutputFile;
 
+    @Override
+    protected boolean isAllowSnapshots() {
+        // this parameter is used by base class, but shouldn't affect comparison; setting to true
+        return true;
+    }
+
     /**
      * The (injected) instance of {@link ProjectBuilder}
      *

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -310,6 +310,19 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
     @Parameter(property = "pluginManagementDependencyExcludes")
     private List<String> pluginManagementDependencyExcludes;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // --------------------- GETTER / SETTER METHODS ---------------------
 
     @Inject

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayExtensionUpdatesMojo.java
@@ -145,6 +145,19 @@ public class DisplayExtensionUpdatesMojo extends AbstractVersionsDisplayMojo {
     @Parameter(property = "verbose", defaultValue = "false")
     private boolean verbose;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     @Inject
     public DisplayExtensionUpdatesMojo(
             ArtifactHandlerManager artifactHandlerManager,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojo.java
@@ -131,6 +131,19 @@ public class DisplayParentUpdatesMojo extends AbstractVersionsDisplayMojo {
     @Parameter(property = "allowIncrementalUpdates", defaultValue = "true")
     protected boolean allowIncrementalUpdates = true;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // -------------------------- OTHER METHODS --------------------------
 
     @Inject

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojo.java
@@ -171,6 +171,19 @@ public class DisplayPluginUpdatesMojo extends AbstractVersionsDisplayMojo {
     @Parameter(property = "processUnboundPlugins", defaultValue = "false")
     protected boolean processUnboundPlugins;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // --------------------- GETTER / SETTER METHODS ---------------------
 
     @Inject

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -139,6 +139,19 @@ public class DisplayPropertyUpdatesMojo extends AbstractVersionsDisplayMojo {
     @Parameter(property = "includeParent", defaultValue = "false")
     protected boolean includeParent;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // -------------------------- STATIC METHODS --------------------------
 
     // -------------------------- OTHER METHODS --------------------------

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
@@ -60,6 +60,11 @@ public class ForceReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
     @Parameter(property = "failIfNotReplaced", defaultValue = "false")
     protected boolean failIfNotReplaced;
 
+    @Override
+    protected boolean isAllowSnapshots() {
+        return false;
+    }
+
     // ------------------------------ METHODS --------------------------
 
     @Inject

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/LockSnapshotsMojo.java
@@ -69,6 +69,12 @@ public class LockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo {
 
     // ------------------------------ METHODS --------------------------
 
+    @Override
+    protected boolean isAllowSnapshots() {
+        // used by base method; must be true so that it's able to select snapshots
+        return true;
+    }
+
     @Inject
     public LockSnapshotsMojo(
             ArtifactHandlerManager artifactHandlerManager,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ResolveRangesMojo.java
@@ -121,6 +121,19 @@ public class ResolveRangesMojo extends AbstractVersionsDependencyUpdaterMojo {
     @Parameter(property = "allowIncrementalUpdates", defaultValue = "true")
     private boolean allowIncrementalUpdates;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // ------------------------------ FIELDS ------------------------------
 
     /**

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -240,6 +240,19 @@ public class SetMojo extends AbstractVersionsUpdaterMojo {
     private String updateBuildOutputTimestampPolicy;
 
     /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
+    /**
      * The changes to module coordinates. Guarded by this.
      */
     private final transient List<DefaultDependencyVersionChange> sourceChanges = new ArrayList<>();

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -94,6 +94,19 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
     @Parameter(property = "profileId")
     private String profileId = null;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     @Inject
     public SetPropertyMojo(
             ArtifactHandlerManager artifactHandlerManager,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetScmTagMojo.java
@@ -64,6 +64,19 @@ public class SetScmTagMojo extends AbstractVersionsUpdaterMojo {
     @Parameter(property = "url")
     private String url;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     @Inject
     public SetScmTagMojo(
             ArtifactHandlerManager artifactHandlerManager,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UnlockSnapshotsMojo.java
@@ -61,6 +61,12 @@ public class UnlockSnapshotsMojo extends AbstractVersionsDependencyUpdaterMojo {
 
     // ------------------------------ METHODS --------------------------
 
+    @Override
+    protected boolean isAllowSnapshots() {
+        // used by base class; must be true so that it can select snapshots
+        return true;
+    }
+
     @Inject
     public UnlockSnapshotsMojo(
             ArtifactHandlerManager artifactHandlerManager,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateChildModulesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateChildModulesMojo.java
@@ -35,6 +35,7 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
@@ -64,6 +65,19 @@ public class UpdateChildModulesMojo extends AbstractVersionsUpdaterMojo {
      * The version that we are updating to. Guarded by this.
      */
     private transient String sourceVersion = null;
+
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
 
     @Inject
     public UpdateChildModulesMojo(

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdateParentMojo.java
@@ -130,6 +130,19 @@ public class UpdateParentMojo extends AbstractVersionsUpdaterMojo {
     @Parameter(property = "allowIncrementalUpdates", defaultValue = "true")
     protected boolean allowIncrementalUpdates = true;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     // -------------------------- OTHER METHODS --------------------------
 
     @Inject

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojoBase.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojoBase.java
@@ -107,6 +107,19 @@ public abstract class UpdatePropertiesMojoBase extends AbstractVersionsDependenc
     @Parameter(property = "includeParent", defaultValue = "true")
     protected boolean includeParent = true;
 
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
     public UpdatePropertiesMojoBase(
             ArtifactHandlerManager artifactHandlerManager,
             RepositorySystem repositorySystem,

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -91,6 +91,19 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
     protected boolean forceVersion;
 
     /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
+
+    /**
      * <p>Will augment normal processing by, if a dependency value is set using a property, trying to update
      * the value of the property.</p>
      * <p>If the property value is specified directly, will process it normally (as with {@code processProperties} being

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseNextReleasesMojo.java
@@ -16,34 +16,20 @@ package org.codehaus.mojo.versions;
  */
 
 import javax.inject.Inject;
-import javax.xml.stream.XMLStreamException;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.mojo.versions.api.PomHelper;
-import org.codehaus.mojo.versions.api.VersionRetrievalException;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
-import org.codehaus.mojo.versions.api.recording.DependencyChangeRecord;
-import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.rewriting.MutableXMLStreamReader;
 import org.eclipse.aether.RepositorySystem;
-
-import static java.util.Collections.singletonList;
-import static org.codehaus.mojo.versions.api.recording.DependencyChangeRecord.ChangeKind.DEPENDENCY;
-import static org.codehaus.mojo.versions.api.recording.DependencyChangeRecord.ChangeKind.DEPENDENCY_MANAGEMENT;
-import static org.codehaus.mojo.versions.api.recording.DependencyChangeRecord.ChangeKind.PARENT;
 
 /**
  * Replaces any release versions with the next release version (if it has been released).
@@ -73,55 +59,43 @@ public class UseNextReleasesMojo extends UseLatestVersionsMojoBase {
         super(artifactHandlerManager, repositorySystem, wagonMap, changeRecorders);
     }
 
-    /**
-     * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException when things go wrong with XML streaming
-     * @see AbstractVersionsUpdaterMojo#update(MutableXMLStreamReader)
-     */
-    protected void update(MutableXMLStreamReader pom)
-            throws MojoExecutionException, MojoFailureException, XMLStreamException, VersionRetrievalException {
-        try {
-            if (isProcessingDependencyManagement()) {
-                DependencyManagement dependencyManagement =
-                        PomHelper.getRawModel(getProject()).getDependencyManagement();
-                if (dependencyManagement != null) {
-                    useNextReleases(pom, dependencyManagement.getDependencies(), DEPENDENCY_MANAGEMENT);
-                }
-            }
-
-            if (getProject().getDependencies() != null && isProcessingDependencies()) {
-                useNextReleases(pom, getProject().getDependencies(), DEPENDENCY);
-            }
-
-            if (getProject().getParent() != null && isProcessingParent()) {
-                useNextReleases(pom, singletonList(getParentDependency()), PARENT);
-            }
-        } catch (IOException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        }
+    @Override
+    protected boolean isAllowMajorUpdates() {
+        return true;
     }
 
-    private void useNextReleases(
-            MutableXMLStreamReader pom,
-            Collection<Dependency> dependencies,
-            DependencyChangeRecord.ChangeKind changeKind)
-            throws XMLStreamException, MojoExecutionException, VersionRetrievalException {
-        useLatestVersions(
-                pom,
-                dependencies,
-                (dep, versions) -> {
-                    try {
-                        return Arrays.stream(versions.getNewerVersions(
-                                        dep.getVersion(), Optional.empty(), false, allowDowngrade))
-                                .findFirst();
-                    } catch (InvalidSegmentException e) {
-                        throw new RuntimeException(e);
-                    }
-                },
-                changeKind,
-                dep -> allowDowngrade
-                        || !SNAPSHOT_REGEX.matcher(dep.getVersion()).matches());
+    @Override
+    protected boolean isAllowMinorUpdates() {
+        return true;
+    }
+
+    @Override
+    protected boolean isAllowIncrementalUpdates() {
+        return true;
+    }
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return false;
+    }
+
+    @Override
+    protected boolean isAllowDowngrade() {
+        return allowDowngrade;
+    }
+
+    @Override
+    protected boolean updateFilter(Dependency dep) {
+        return allowDowngrade || !ArtifactUtils.isSnapshot(dep.getVersion());
+    }
+
+    @Override
+    protected boolean artifactVersionsFilter(ArtifactVersion ver) {
+        return true;
+    }
+
+    @Override
+    protected Optional<ArtifactVersion> versionProducer(Stream<ArtifactVersion> stream) {
+        return stream.findFirst();
     }
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseNextSnapshotsMojo.java
@@ -16,38 +16,20 @@ package org.codehaus.mojo.versions;
  */
 
 import javax.inject.Inject;
-import javax.xml.stream.XMLStreamException;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.wagon.Wagon;
-import org.codehaus.mojo.versions.api.PomHelper;
-import org.codehaus.mojo.versions.api.Segment;
-import org.codehaus.mojo.versions.api.VersionRetrievalException;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
-import org.codehaus.mojo.versions.api.recording.DependencyChangeRecord;
-import org.codehaus.mojo.versions.ordering.InvalidSegmentException;
-import org.codehaus.mojo.versions.rewriting.MutableXMLStreamReader;
 import org.eclipse.aether.RepositorySystem;
-
-import static java.util.Collections.singletonList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static org.codehaus.mojo.versions.api.Segment.INCREMENTAL;
-import static org.codehaus.mojo.versions.api.Segment.MAJOR;
-import static org.codehaus.mojo.versions.api.Segment.MINOR;
 
 /**
  * Replaces any release versions with the next snapshot version (if it has been deployed).
@@ -94,80 +76,45 @@ public class UseNextSnapshotsMojo extends UseLatestVersionsMojoBase {
             Map<String, Wagon> wagonMap,
             Map<String, ChangeRecorder> changeRecorders) {
         super(artifactHandlerManager, repositorySystem, wagonMap, changeRecorders);
-        // the below is necessary for UseLatestVersionsMojoBase.useLatestVersions to select snapshots
-        allowSnapshots = true;
     }
 
-    /**
-     * @param pom the pom to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong
-     * @throws org.apache.maven.plugin.MojoFailureException   when things go wrong in a very bad way
-     * @throws javax.xml.stream.XMLStreamException            when things go wrong with XML streaming
-     * @see org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo#update(MutableXMLStreamReader)
-     */
-    protected void update(MutableXMLStreamReader pom)
-            throws MojoExecutionException, MojoFailureException, XMLStreamException, VersionRetrievalException {
-        try {
-            DependencyManagement dependencyManagement =
-                    PomHelper.getRawModel(getProject()).getDependencyManagement();
-            if (dependencyManagement != null) {
-                useNextSnapshots(
-                        pom,
-                        dependencyManagement.getDependencies(),
-                        DependencyChangeRecord.ChangeKind.DEPENDENCY_MANAGEMENT);
-            }
-            if (getProject().getDependencies() != null && isProcessingDependencies()) {
-                useNextSnapshots(pom, getProject().getDependencies(), DependencyChangeRecord.ChangeKind.DEPENDENCY);
-            }
-            if (getProject().getParent() != null && isProcessingParent()) {
-                useNextSnapshots(pom, singletonList(getParentDependency()), DependencyChangeRecord.ChangeKind.PARENT);
-            }
-        } catch (IOException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
-        }
+    @Override
+    protected boolean isAllowMajorUpdates() {
+        return allowMajorUpdates;
     }
 
-    private void useNextSnapshots(
-            MutableXMLStreamReader pom,
-            Collection<Dependency> dependencies,
-            DependencyChangeRecord.ChangeKind changeKind)
-            throws XMLStreamException, MojoExecutionException, VersionRetrievalException {
-        Log log = getLog();
-        if (log != null && !allowIncrementalUpdates) {
-            log.info("Assuming allowMinorUpdates false because allowIncrementalUpdates is false.");
-        }
+    @Override
+    protected boolean isAllowMinorUpdates() {
+        return allowMinorUpdates;
+    }
 
-        if (log != null && !allowMinorUpdates) {
-            log.info("Assuming allowMajorUpdates false because allowMinorUpdates is false.");
-        }
+    @Override
+    protected boolean isAllowIncrementalUpdates() {
+        return allowIncrementalUpdates;
+    }
 
-        Optional<Segment> unchangedSegment = allowMajorUpdates && allowMinorUpdates && allowIncrementalUpdates
-                ? empty()
-                : allowMinorUpdates && allowIncrementalUpdates
-                        ? of(MAJOR)
-                        : allowIncrementalUpdates ? of(MINOR) : of(INCREMENTAL);
-        if (log != null && log.isDebugEnabled()) {
-            log.debug(unchangedSegment
-                            .map(Segment::minorTo)
-                            .map(Segment::toString)
-                            .orElse("ALL") + " version changes allowed");
-        }
+    @Override
+    protected boolean isAllowSnapshots() {
+        return true;
+    }
 
-        useLatestVersions(
-                pom,
-                dependencies,
-                (dep, versions) -> {
-                    try {
-                        return Arrays.stream(versions.getNewerVersions(dep.getVersion(), unchangedSegment, true, false))
-                                .filter(v ->
-                                        SNAPSHOT_REGEX.matcher(v.toString()).matches())
-                                .findFirst();
-                    } catch (InvalidSegmentException e) {
-                        getLog().info("Ignoring " + toString(dep) + " as the version number is too short");
-                        return empty();
-                    }
-                },
-                changeKind,
-                dep -> !SNAPSHOT_REGEX.matcher(dep.getVersion()).matches());
+    @Override
+    protected boolean isAllowDowngrade() {
+        return false;
+    }
+
+    @Override
+    protected boolean updateFilter(Dependency dep) {
+        return !ArtifactUtils.isSnapshot(dep.getVersion());
+    }
+
+    @Override
+    protected boolean artifactVersionsFilter(ArtifactVersion ver) {
+        return ArtifactUtils.isSnapshot(ver.toString());
+    }
+
+    @Override
+    protected Optional<ArtifactVersion> versionProducer(Stream<ArtifactVersion> stream) {
+        return stream.findFirst();
     }
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReactorMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.api.PomHelper;
@@ -50,6 +51,19 @@ import org.eclipse.aether.RepositorySystem;
  */
 @Mojo(name = "use-reactor", threadSafe = true)
 public class UseReactorMojo extends AbstractVersionsDependencyUpdaterMojo {
+
+    /**
+     * Whether to allow snapshots when searching for the latest version of an artifact.
+     *
+     * @since 1.0-alpha-1
+     */
+    @Parameter(property = "allowSnapshots", defaultValue = "false")
+    protected boolean allowSnapshots;
+
+    @Override
+    protected boolean isAllowSnapshots() {
+        return allowSnapshots;
+    }
 
     // ------------------------------ METHODS --------------------------
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -74,6 +74,11 @@ public class UseReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
     @Parameter(property = "failIfNotReplaced", defaultValue = "false")
     protected boolean failIfNotReplaced;
 
+    @Override
+    protected boolean isAllowSnapshots() {
+        return false;
+    }
+
     // ------------------------------ METHODS --------------------------
 
     @Inject

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SeparatePatternsForIncludesAnExcludesTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SeparatePatternsForIncludesAnExcludesTest.java
@@ -16,6 +16,11 @@ public class SeparatePatternsForIncludesAnExcludesTest {
     public void setUp() throws Exception {
         mojo = new AbstractVersionsDependencyUpdaterMojo(null, null, null, null) {
             @Override
+            protected boolean isAllowSnapshots() {
+                return false;
+            }
+
+            @Override
             protected void update(MutableXMLStreamReader pom) {}
         };
     }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestSnapshotsMojoTest.java
@@ -1,0 +1,74 @@
+package org.codehaus.mojo.versions;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.VersionRetrievalException;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactHandlerManager;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockMavenSession;
+
+public class UseLatestSnapshotsMojoTest extends UseLatestVersionsMojoTestBase {
+    @Before
+    public void setUp() throws Exception {
+        changeRecorder = createChangeRecorder();
+        mojo =
+                new UseLatestSnapshotsMojo(
+                        mockArtifactHandlerManager(), createRepositorySystem(), null, changeRecorder.asTestMap()) {
+                    {
+                        reactorProjects = emptyList();
+                        MavenProject project = new MavenProject() {
+                            {
+                                setModel(new Model() {
+                                    {
+                                        setGroupId("default-group");
+                                        setArtifactId("project-artifact");
+                                        setVersion("1.0.0-SNAPSHOT");
+
+                                        setDependencies(singletonList(DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("dependency-artifact")
+                                                .withVersion("0.9.0")
+                                                .withScope(SCOPE_COMPILE)
+                                                .withType("jar")
+                                                .withClassifier("default")
+                                                .build()));
+                                    }
+                                });
+                            }
+                        };
+                        setProject(project);
+
+                        session = mockMavenSession();
+                        allowMajorUpdates = true;
+                        allowMinorUpdates = true;
+                        allowIncrementalUpdates = true;
+                    }
+                };
+    }
+
+    @Test
+    @Override
+    public void testIncludeFilter()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        testIncludeFilter("2.0-SNAPSHOT");
+    }
+
+    @Test
+    @Override
+    public void testExcludeFilter()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        testExcludeFilter("2.0-SNAPSHOT");
+    }
+}

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTestBase.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTestBase.java
@@ -1,0 +1,168 @@
+package org.codehaus.mojo.versions;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.api.VersionRetrievalException;
+import org.codehaus.mojo.versions.change.DefaultDependencyVersionChange;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.codehaus.mojo.versions.utils.TestChangeRecorder;
+import org.eclipse.aether.RepositorySystem;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
+import static org.apache.maven.plugin.testing.ArtifactStubFactory.setVariableValueToObject;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySystem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+public abstract class UseLatestVersionsMojoTestBase {
+    protected UseLatestVersionsMojoBase mojo;
+
+    protected TestChangeRecorder changeRecorder;
+
+    protected RepositorySystem createRepositorySystem() {
+        return mockAetherRepositorySystem(new HashMap<String, String[]>() {
+            {
+                put("dependency-artifact", new String[] {
+                    "1.1.1-SNAPSHOT", "1.1.0", "1.1.0-SNAPSHOT", "1.0.0", "1.0.0-beta", "1.0.0-SNAPSHOT", "0.9.0"
+                });
+                put("poison-artifact", new String[] {
+                    "1.1.1.1-SNAPSHOT", "1.1.1.0", "1.1.1.0-SNAPSHOT", "1.0.0.0", "1.0.0.0-SNAPSHOT", "0.9.0.0"
+                });
+                put("other-artifact", new String[] {"1.0", "2.0", "2.0-SNAPSHOT"});
+            }
+        });
+    }
+
+    protected TestChangeRecorder createChangeRecorder() {
+        return new TestChangeRecorder();
+    }
+
+    protected void tryUpdate()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, VersionRetrievalException {
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(true);
+            pomHelper
+                    .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
+                    .thenReturn(mojo.getProject().getModel());
+            mojo.update(null);
+        }
+    }
+
+    @Test
+    public void testIgnoredVersions()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        setVariableValueToObject(mojo, "processDependencies", true);
+        setVariableValueToObject(mojo, "ignoredVersions", new HashSet<String>() {
+            {
+                add("1.0.0");
+                add("1.0.0-beta");
+                add("1.1.0");
+                add("1.0.0-SNAPSHOT");
+                add("1.1.0-SNAPSHOT");
+                add("1.1.1-SNAPSHOT");
+            }
+        });
+
+        tryUpdate();
+        assertThat(changeRecorder.getChanges(), Is.is(empty()));
+    }
+
+    protected void testIncludeFilter(String expectedNewVersion)
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        mojo.getProject()
+                .getModel()
+                .setDependencies(Arrays.asList(
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("0.9.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build(),
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("other-artifact")
+                                .withVersion("1.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
+        setVariableValueToObject(mojo, "processDependencies", true);
+        setVariableValueToObject(mojo, "includes", new String[] {"default-group:other-artifact"});
+
+        tryUpdate();
+        assertThat(changeRecorder.getChanges(), hasSize(1));
+        assertThat(
+                changeRecorder.getChanges(),
+                hasItem(new DefaultDependencyVersionChange(
+                        "default-group", "other-artifact", "1.0", expectedNewVersion)));
+    }
+
+    @Test
+    public void testIncludeFilter()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        testIncludeFilter("2.0");
+    }
+
+    protected void testExcludeFilter(String expectedNewVersion)
+            throws IllegalAccessException, MojoExecutionException, XMLStreamException, MojoFailureException,
+                    VersionRetrievalException {
+        mojo.getProject()
+                .getModel()
+                .setDependencies(Arrays.asList(
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("dependency-artifact")
+                                .withVersion("0.9.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build(),
+                        DependencyBuilder.newBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("other-artifact")
+                                .withVersion("1.0")
+                                .withType("pom")
+                                .withClassifier("default")
+                                .withScope(SCOPE_COMPILE)
+                                .build()));
+        setVariableValueToObject(mojo, "processDependencies", true);
+        setVariableValueToObject(mojo, "excludes", new String[] {"default-group:other-artifact"});
+
+        tryUpdate();
+        assertThat(changeRecorder.getChanges(), hasSize(1));
+        assertThat(
+                changeRecorder.getChanges(),
+                not(hasItem(new DefaultDependencyVersionChange(
+                        "default-group", "other-artifact", "1.0", expectedNewVersion))));
+    }
+
+    @Test
+    public void testExcludeFilter()
+            throws MojoExecutionException, XMLStreamException, MojoFailureException, IllegalAccessException,
+                    VersionRetrievalException {
+        testExcludeFilter("2.0");
+    }
+}


### PR DESCRIPTION
I wanted to try and do something similar to what mojohaus/versions#292 was, but since the plugin has moved on, it first needs some refactoring.

This PR makes the use-\*-\* goals use shared codebase in order to make future refactoring simpler.