### PR TITLE
PR Automation - must use pull_request_target

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -17,14 +17,11 @@
 
 name: PR Automation
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - unlabeled
       - demilestoned
-  pull_request_review:
-    types:
-      - submitted
 
 jobs:
   pr-automation:


### PR DESCRIPTION
Only `pull_request_target` - use GITHUB_TOKEN with write access for PR from forked repository

We need a write access to change a label or milestone.