### PR TITLE
Exposing the problem causing artifact if Resolver throws an exception

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionRetrievalException.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionRetrievalException.java
@@ -19,17 +19,26 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.Optional;
+
+import org.apache.maven.artifact.Artifact;
+
 /**
  * Exception thrown if version information cannot be retrieved
  */
 public class VersionRetrievalException extends Exception {
+
+    private final Artifact artifact;
+
     /**
      * Constructs a new exception with {@code null} as its detail message.
      * The cause is not initialized, and may subsequently be initialized by a
      * call to {@link #initCause}.
+     *
+     * @param artifact {@link Artifact} instance causing the problem
      */
-    public VersionRetrievalException() {
-        super();
+    public VersionRetrievalException(Artifact artifact) {
+        this(null, artifact);
     }
 
     /**
@@ -37,11 +46,13 @@ public class VersionRetrievalException extends Exception {
      * cause is not initialized, and may subsequently be initialized by
      * a call to {@link #initCause}.
      *
+     * @param artifact {@link Artifact} instance causing the problem
      * @param   message   the detail message. The detail message is saved for
      *          later retrieval by the {@link #getMessage()} method.
      */
-    public VersionRetrievalException(String message) {
+    public VersionRetrievalException(String message, Artifact artifact) {
         super(message);
+        this.artifact = artifact;
     }
 
     /**
@@ -52,13 +63,14 @@ public class VersionRetrievalException extends Exception {
      * wrappers for other throwables (for example, {@link
      * java.security.PrivilegedActionException}).
      *
+     * @param artifact {@link Artifact} instance causing the problem
      * @param  cause the cause (which is saved for later retrieval by the
      *         {@link #getCause()} method).  (A {@code null} value is
      *         permitted, and indicates that the cause is nonexistent or
      *         unknown.)
      */
-    public VersionRetrievalException(Throwable cause) {
-        super(cause);
+    public VersionRetrievalException(Artifact artifact, Throwable cause) {
+        this(null, artifact, cause);
     }
 
     /**
@@ -69,12 +81,22 @@ public class VersionRetrievalException extends Exception {
      *
      * @param  message the detail message (which is saved for later retrieval
      *         by the {@link #getMessage()} method).
+     * @param artifact {@link Artifact} instance causing the problem
      * @param  cause the cause (which is saved for later retrieval by the
      *         {@link #getCause()} method).  (A {@code null} value is
      *         permitted, and indicates that the cause is nonexistent or
      *         unknown.)
      */
-    public VersionRetrievalException(String message, Throwable cause) {
+    public VersionRetrievalException(String message, Artifact artifact, Throwable cause) {
         super(message, cause);
+        this.artifact = artifact;
+    }
+
+    /**
+     * Returns the artifact causing the problem with version retrieval, if available
+     * @return {@link Optional} object containing artifact causing the problem with version retrieval, or empty
+     */
+    public Optional<Artifact> getArtifact() {
+        return Optional.ofNullable(artifact);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/MavenProjectUtils.java
@@ -113,19 +113,15 @@ public class MavenProjectUtils {
                                 .orElse(Stream.empty()));
 
         // log and try to correct versions where they don't appear in the original pom.xml
-        try {
-            return dependencies
-                    .peek(dependency -> log.debug("dependency from pom: "
-                            + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion()
-                            + ":" + dependency.getScope()))
-                    .map(dependency -> dependency.getVersion() != null
-                            ? interpolateVersion(dependency, project)
-                            : getVersionFromParent(dependency, project, processDependencyManagementTransitive, log)
-                                    .orElse(dependency))
-                    .collect(() -> new TreeSet<>(DependencyComparator.INSTANCE), Set::add, Set::addAll);
-        } catch (IllegalArgumentException e) {
-            throw new VersionRetrievalException(e.getMessage());
-        }
+        return dependencies
+                .peek(dependency -> log.debug("dependency from pom: "
+                        + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion()
+                        + ":" + dependency.getScope()))
+                .map(dependency -> dependency.getVersion() != null
+                        ? interpolateVersion(dependency, project)
+                        : getVersionFromParent(dependency, project, processDependencyManagementTransitive, log)
+                                .orElse(dependency))
+                .collect(() -> new TreeSet<>(DependencyComparator.INSTANCE), Set::add, Set::addAll);
     }
 
     /**

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersionTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/ordering/BoundArtifactVersionTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.lessThan;
  * Unit tests for {@link BoundArtifactVersion}
  */
 class BoundArtifactVersionTest {
+
     @Test
     void testMajorUpperBoundGreaterThanNextMajor() {
         BoundArtifactVersion bound = new BoundArtifactVersion("1.2.3", MAJOR);

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractDependencyUpdatesReport.java
@@ -197,17 +197,17 @@ public abstract class AbstractDependencyUpdatesReport extends AbstractVersionsRe
 
             renderReport(locale, sink, model);
         } catch (VersionRetrievalException e) {
-            throw new RuntimeException(e);
+            throw new MavenReportException(e.getMessage(), e);
         }
     }
 
     protected void handleDependencyManagementTransitive(
-            MavenProject project, Set<Dependency> dependencyManagementCollector) {
+            MavenProject project, Set<Dependency> dependencyManagementCollector) throws MavenReportException {
         try {
             dependencyManagementCollector.addAll(MavenProjectUtils.extractDependenciesFromDependencyManagement(
                     project, processDependencyManagementTransitive, getLog()));
         } catch (VersionRetrievalException e) {
-            throw new RuntimeException(e);
+            throw new MavenReportException(e.getMessage(), e);
         }
     }
 

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesAggregateReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesAggregateReport.java
@@ -26,6 +26,7 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.mojo.versions.reporting.util.AggregateReportUtils;
@@ -70,7 +71,8 @@ public class DependencyUpdatesAggregateReport extends AbstractDependencyUpdatesR
      * {@inheritDoc}
      * */
     @Override
-    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector) {
+    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector)
+            throws MavenReportException {
         for (MavenProject project : AggregateReportUtils.getProjectsToProcess(getProject())) {
             getLog().debug(String.format("Collecting managed dependencies for project %s", project.getName()));
             handleDependencyManagementTransitive(project, dependencyManagementCollector);

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DependencyUpdatesReport.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.mojo.versions.utils.ArtifactFactory;
@@ -66,7 +67,8 @@ public class DependencyUpdatesReport extends AbstractDependencyUpdatesReport {
      * {@inheritDoc}
      * */
     @Override
-    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector) {
+    protected void populateDependencyManagement(Set<Dependency> dependencyManagementCollector)
+            throws MavenReportException {
         if (hasDependencyManagement(getProject())) {
             getLog().debug(String.format(
                     "Collecting managed dependencies for project %s",

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseDepVersionMojo.java
@@ -283,7 +283,9 @@ public class UseDepVersionMojo extends AbstractVersionsDependencyUpdaterMojo {
                     "Unable to parse the pom " + node.getModel().getPomFile(), e);
         } catch (VersionRetrievalException e) {
             throw new MojoFailureException(
-                    "Unable to retrieve a dependency version while processing "
+                    "Unable to retrieve dependency versions "
+                            + e.getArtifact().map(a -> "of " + a).orElse("")
+                            + " while processing "
                             + node.getModel().getPomFile(),
                     e);
         }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -194,8 +194,8 @@ public class UseReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
                 // Force releaseVersion version because org.apache.maven.artifact.metadata.MavenMetadataSource does not
                 // retrieve release version if provided snapshot version.
                 artifact.setVersion(releaseVersion);
-                Optional<String> targetVersion = findReleaseVersion(
-                        pom, dep, version, releaseVersion, getHelper().lookupArtifactVersions(artifact, false));
+                Optional<String> targetVersion =
+                        findReleaseVersion(releaseVersion, getHelper().lookupArtifactVersions(artifact, false));
                 if (targetVersion.isPresent()) {
                     updateDependencyVersion(pom, dep, targetVersion.get(), changeKind);
                 } else {
@@ -209,12 +209,7 @@ public class UseReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
         }
     }
 
-    private Optional<String> findReleaseVersion(
-            MutableXMLStreamReader pom,
-            Dependency dep,
-            String version,
-            String releaseVersion,
-            ArtifactVersions versions) {
+    private Optional<String> findReleaseVersion(String releaseVersion, ArtifactVersions versions) {
         return !allowRangeMatching
                 ? versions.containsVersion(releaseVersion) ? Optional.of(releaseVersion) : Optional.empty()
                 : Arrays.stream(versions.getVersions(false))

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PropertyUpdatesReportTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/PropertyUpdatesReportTest.java
@@ -23,11 +23,15 @@ import java.io.File;
 import java.io.OutputStream;
 import java.util.Locale;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.doxia.module.xhtml5.Xhtml5SinkFactory;
 import org.apache.maven.doxia.sink.SinkFactory;
 import org.apache.maven.doxia.tools.SiteTool;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.reporting.MavenReportException;
+import org.codehaus.mojo.versions.api.VersionRetrievalException;
 import org.eclipse.aether.RepositorySystem;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +40,8 @@ import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySys
 import static org.codehaus.mojo.versions.utils.MockUtils.mockSiteTool;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 /**
@@ -86,5 +92,28 @@ public class PropertyUpdatesReportTest extends AbstractMojoTestCase {
                 .replaceAll("&[^;]+;", " ")
                 .replaceAll("\\s+", " ");
         assertThat(output, not(containsString("${ver}")));
+    }
+
+    @Test
+    public void testProblemCausingArtifact() throws Exception {
+        OutputStream os = new ByteArrayOutputStream();
+        SinkFactory sinkFactory = new Xhtml5SinkFactory();
+
+        PropertyUpdatesReport mojo = (PropertyUpdatesReport) mojoRule.lookupConfiguredMojo(
+                new File("src/test/resources/org/codehaus/mojo/update-properties/problem-causing"),
+                "property-updates-report");
+        setVariableValueToObject(mojo, "siteTool", SITE_TOOL);
+        setVariableValueToObject(mojo, "repositorySystem", AETHER_REPOSITORY_SYSTEM);
+
+        try {
+            mojo.generate(sinkFactory.createSink(os), sinkFactory, Locale.getDefault());
+            fail("Should throw an exception");
+        } catch (MavenReportException e) {
+            assertThat(e.getCause(), instanceOf(MojoExecutionException.class));
+            MojoExecutionException moe = (MojoExecutionException) e.getCause();
+            assertThat(moe.getCause(), instanceOf(VersionRetrievalException.class));
+            VersionRetrievalException vre = (VersionRetrievalException) moe.getCause();
+            assertThat(vre.getArtifact().map(Artifact::getArtifactId).orElse(""), equalTo("problem-causing-artifact"));
+        }
     }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertiesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertiesMojoTest.java
@@ -105,4 +105,9 @@ public class UpdatePropertiesMojoTest extends UpdatePropertiesMojoTestBase {
         mojo.execute();
         assertThat(changeRecorder.getChanges(), is(empty()));
     }
+
+    @Test
+    public void testProblemCausingArtifact() throws Exception {
+        testProblemCausingArtifact("update-properties");
+    }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertyMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UpdatePropertyMojoTest.java
@@ -76,4 +76,9 @@ public class UpdatePropertyMojoTest extends UpdatePropertiesMojoTestBase {
                 Matchers.hasItem(
                         new DefaultDependencyVersionChange("default-group", "default-artifact", "1.0.0", "1.0.1-rc1")));
     }
+
+    @Test
+    public void testProblemCausingArtifact() throws Exception {
+        testProblemCausingArtifact("update-property", m -> ((UpdatePropertyMojo) m).property = "artifact-version");
+    }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/problem-causing/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/problem-causing/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>problem-causing-artifact</artifactId>
+            <version>1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/problem-causing.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/problem-causing.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>default-group</groupId>
+                <artifactId>problem-causing-artifact</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/problem-causing/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/update-properties/problem-causing/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <properties>
+        <artifact-version>1.0.0</artifact-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>problem-causing-artifact</artifactId>
+            <version>${artifact-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/problem-causing/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/problem-causing/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test-group</groupId>
+    <artifactId>test-artifact</artifactId>
+    <version>DEVELOP-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>test-group</groupId>
+            <artifactId>problem-causing-artifact</artifactId>
+            <version>1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <includesList>test-group:problem-causing-artifact</includesList>
+                    <depVersion>2</depVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Any problems causing the Resolver to fail resolving a version should be reported to the end user,  including the artifact causing the problem which can facilitate problem resolution on the resolver end. 

Here we're propagating the information about the problematic artifact to the mojo which can then output it in the log.

Related: #1147 