### PR TITLE
Fixed #1233- set-property in profile without module  property

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -171,8 +171,19 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
             Property currentProperty = entry.getKey();
             PropertyVersions version = entry.getValue();
             String newVersionGiven = currentProperty.getVersion();
-            final String profileToApply = isEmpty(profileId) ? version.getProfileId() : profileId;
-            final String currentVersion = getProject().getProperties().getProperty(currentProperty.getName());
+            String profileToApply;
+            String currentVersion;
+            if (isEmpty(profileId)) {
+                profileToApply = version.getProfileId();
+                currentVersion = getProject().getProperties().getProperty(currentProperty.getName());
+            } else {
+                profileToApply = profileId;
+                currentVersion = getProject().getModel().getProfiles().stream()
+                        .filter(profile -> profileId.equals(profile.getId()))
+                        .findFirst()
+                        .map(profile -> profile.getProperties().getProperty(currentProperty.getName()))
+                        .orElse(null);
+            }
             if (currentVersion == null) {
                 continue;
             }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetPropertyMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetPropertyMojoTest.java
@@ -128,11 +128,22 @@ public class SetPropertyMojoTest extends AbstractMojoTestCase {
     }
 
     @Test
-    public void testChangeOnlyPropertiesInTheProfile() throws Exception {
-        final String newVersion = UUID.randomUUID().toString();
-        final Model model = getModelForProfile("test-profile", true, newVersion);
+    public void testChangeOnlyPropertiesInTheProfileWithPropertyAlsoInTheModule() throws Exception {
+        testChangeOnlyPropertiesInTheProfile(true);
+    }
 
-        assertThat(model.getProperties().getProperty("dummy-api-version"), is("1.0.0"));
+    @Test
+    public void testChangeOnlyPropertiesInTheProfileWithPropertyOnlyInProfile() throws Exception {
+        testChangeOnlyPropertiesInTheProfile(false);
+    }
+
+    private void testChangeOnlyPropertiesInTheProfile(boolean withPropertyInTheModule) throws Exception {
+        final String newVersion = UUID.randomUUID().toString();
+        final Model model = getModelForProfile("test-profile", true, newVersion, withPropertyInTheModule);
+
+        if (withPropertyInTheModule) {
+            assertThat(model.getProperties().getProperty("dummy-api-version"), is("1.0.0"));
+        }
         assertThat(
                 model.getProfiles().stream()
                         .filter(profile -> "test-profile".equals(profile.getId()))
@@ -181,7 +192,15 @@ public class SetPropertyMojoTest extends AbstractMojoTestCase {
     }
 
     private Model getModelForProfile(String profileName, Boolean setProfile, String newVersion) throws Exception {
-        copyDir(Paths.get("src/test/resources/org/codehaus/mojo/set-property/profiled-new-version"), pomDir);
+        return getModelForProfile(profileName, setProfile, newVersion, true);
+    }
+
+    private Model getModelForProfile(
+            String profileName, Boolean setProfile, String newVersion, Boolean withPropsInModule) throws Exception {
+        final String srcModule = withPropsInModule
+                ? "src/test/resources/org/codehaus/mojo/set-property/profiled-new-version"
+                : "src/test/resources/org/codehaus/mojo/set-property/profiled-new-version-without-props";
+        copyDir(Paths.get(srcModule), pomDir);
         SetPropertyMojo mojo = (SetPropertyMojo) mojoRule.lookupConfiguredMojo(pomDir.toFile(), "set-property");
 
         mojo.repositorySystem = mock(org.eclipse.aether.RepositorySystem.class);

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/profiled-new-version-without-props/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/profiled-new-version-without-props/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>default-artifact</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <property>dummy-api-version</property>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>test-profile</id>
+            <properties>
+                <dummy-api-version>test-value</dummy-api-version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>localhost</groupId>
+                    <artifactId>dummy-api</artifactId>
+                    <version>${dummy-api-version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Handles the case when the property is not in the project properties but it is present in the profile properties