### PR TITLE
Resolves #1251: nextSnapshotIndexToIncrement should zeros on the right

### DIFF
--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/SetMojoTest.java
@@ -265,4 +265,16 @@ public class SetMojoTest extends AbstractMojoTestCase {
                 testLog.getLoggedMessages().stream().map(Triple::getMiddle).collect(Collectors.joining("\n")),
                 not(containsString("Processing change of null:child")));
     }
+
+    @Test
+    public void testNextSnapshotIndexToIncrement() throws MojoExecutionException {
+        new SetMojo(artifactFactory, null, null, null, null, null) {
+            {
+                nextSnapshot = true;
+                assertThat(getIncrementedVersion("1.1.1-SNAPSHOT", 1), is("2.0.0-SNAPSHOT"));
+                assertThat(getIncrementedVersion("1.1.1-SNAPSHOT", 2), is("1.2.0-SNAPSHOT"));
+                assertThat(getIncrementedVersion("1.1.1-SNAPSHOT", 3), is("1.1.2-SNAPSHOT"));
+            }
+        };
+    }
 }


### PR DESCRIPTION
Change in behaviour: `nextSnapshotIndexToIncrement` should make the returned versions contain zeroes on the new version string right to the index pointed to by `nextSnapshotIndexToIncrement`.

I.e. 1.2.3-SNAPSHOT should become 2.0.0-SNAPSHOT and not 2.2.3-SNAPSHOT.

@slawekjaranowski, please review