### PR TITLE
Resolves #1270: Ensuring thread safety when VersionsHelper

### DIFF
--- a/versions-enforcer/src/main/java/org/codehaus/mojo/versions/enforcer/MaxDependencyUpdates.java
+++ b/versions-enforcer/src/main/java/org/codehaus/mojo/versions/enforcer/MaxDependencyUpdates.java
@@ -297,7 +297,7 @@ public class MaxDependencyUpdates extends AbstractEnforcerRule {
      * Creates the VersionsHelper object
      * @return VersionsHelper object
      */
-    private VersionsHelper createVersionsHelper(String serverId, String rulesUri, RuleSet ruleSet)
+    private synchronized VersionsHelper createVersionsHelper(String serverId, String rulesUri, RuleSet ruleSet)
             throws EnforcerRuleError {
         try {
             Log log = new PluginLogWrapper(getLog());

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsReport.java
@@ -167,7 +167,7 @@ public abstract class AbstractVersionsReport<T> extends AbstractMavenReport {
         this.rendererFactory = rendererFactory;
     }
 
-    public VersionsHelper getHelper() throws MavenReportException {
+    public synchronized VersionsHelper getHelper() throws MavenReportException {
         if (helper == null) {
             try {
                 RuleService ruleService = new RulesServiceBuilder()

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -207,7 +207,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
 
     protected abstract boolean getAllowSnapshots();
 
-    public VersionsHelper getHelper() throws MojoExecutionException {
+    public synchronized VersionsHelper getHelper() throws MojoExecutionException {
         if (helper == null) {
             RuleService ruleService = new RulesServiceBuilder()
                     .withMavenSession(session)

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/TestWagonStub.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/TestWagonStub.java
@@ -1,0 +1,134 @@
+package org.codehaus.mojo.versions;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.maven.wagon.ResourceDoesNotExistException;
+import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.Wagon;
+import org.apache.maven.wagon.authentication.AuthenticationInfo;
+import org.apache.maven.wagon.authorization.AuthorizationException;
+import org.apache.maven.wagon.events.SessionListener;
+import org.apache.maven.wagon.events.TransferListener;
+import org.apache.maven.wagon.proxy.ProxyInfo;
+import org.apache.maven.wagon.proxy.ProxyInfoProvider;
+import org.apache.maven.wagon.repository.Repository;
+
+class TestWagonStub implements Wagon {
+    private final Consumer<File> getter;
+
+    TestWagonStub(Consumer<File> getter) {
+        this.getter = getter;
+    }
+
+    @Override
+    public void get(String resourceName, File destination)
+            throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
+        getter.accept(destination);
+    }
+
+    @Override
+    public boolean getIfNewer(String resourceName, File destination, long timestamp) {
+        return false;
+    }
+
+    @Override
+    public void put(File source, String destination)
+            throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {}
+
+    @Override
+    public void putDirectory(File sourceDirectory, String destinationDirectory) {}
+
+    @Override
+    public boolean resourceExists(String resourceName) {
+        return false;
+    }
+
+    @Override
+    public List<String> getFileList(String destinationDirectory) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean supportsDirectoryCopy() {
+        return false;
+    }
+
+    @Override
+    public Repository getRepository() {
+        return null;
+    }
+
+    @Override
+    public void connect(Repository source) {}
+
+    @Override
+    public void connect(Repository source, ProxyInfo proxyInfo) {}
+
+    @Override
+    public void connect(Repository source, ProxyInfoProvider proxyInfoProvider) {}
+
+    @Override
+    public void connect(Repository source, AuthenticationInfo authenticationInfo) {}
+
+    @Override
+    public void connect(Repository source, AuthenticationInfo authenticationInfo, ProxyInfo proxyInfo) {}
+
+    @Override
+    public void connect(
+            Repository source, AuthenticationInfo authenticationInfo, ProxyInfoProvider proxyInfoProvider) {}
+
+    @Override
+    public void openConnection() {}
+
+    @Override
+    public void disconnect() {}
+
+    @Override
+    public void setTimeout(int timeoutValue) {}
+
+    @Override
+    public int getTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setReadTimeout(int timeoutValue) {}
+
+    @Override
+    public int getReadTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void addSessionListener(SessionListener listener) {}
+
+    @Override
+    public void removeSessionListener(SessionListener listener) {}
+
+    @Override
+    public boolean hasSessionListener(SessionListener listener) {
+        return false;
+    }
+
+    @Override
+    public void addTransferListener(TransferListener listener) {}
+
+    @Override
+    public void removeTransferListener(TransferListener listener) {}
+
+    @Override
+    public boolean hasTransferListener(TransferListener listener) {
+        return false;
+    }
+
+    @Override
+    public boolean isInteractive() {
+        return false;
+    }
+
+    @Override
+    public void setInteractive(boolean interactive) {}
+}

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsRaceConditionTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsRaceConditionTest.java
@@ -1,0 +1,178 @@
+package org.codehaus.mojo.versions;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.wagon.Wagon;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.change.DefaultDependencyVersionChange;
+import org.codehaus.mojo.versions.utils.ArtifactFactory;
+import org.codehaus.mojo.versions.utils.DependencyBuilder;
+import org.codehaus.mojo.versions.utils.MockUtils;
+import org.codehaus.mojo.versions.utils.TestChangeRecorder;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static java.util.Collections.emptyList;
+import static org.apache.maven.artifact.Artifact.SCOPE_COMPILE;
+import static org.apache.maven.plugin.testing.ArtifactStubFactory.setVariableValueToObject;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactHandlerManager;
+import static org.codehaus.mojo.versions.utils.MockUtils.mockMavenSession;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class UseLatestVersionsRaceConditionTest {
+    protected UseLatestVersionsMojoBase mojo;
+
+    protected TestChangeRecorder changeRecorder;
+
+    @Mock
+    protected Log log;
+
+    protected PomHelper pomHelper;
+
+    protected ArtifactFactory artifactFactory;
+
+    @Mock
+    protected ExpressionEvaluator expressionEvaluator;
+
+    @Before
+    public void setUp() throws Exception {
+        openMocks(this);
+        changeRecorder = new TestChangeRecorder();
+        ArtifactHandlerManager artifactHandlerManager = mockArtifactHandlerManager();
+        artifactFactory = new ArtifactFactory(artifactHandlerManager);
+        pomHelper = new PomHelper(artifactFactory, expressionEvaluator);
+        mojo = createMojo();
+        mojo.mojoExecution = Mockito.mock(MojoExecution.class);
+    }
+
+    private static String getRulesString() {
+        return "<ruleset>\n"
+                + "  <ignoreVersions>\n"
+                + "    <ignoreVersion type=\"regex\">.*-alpha</ignoreVersion>\n"
+                + "    <ignoreVersion type=\"regex\">.*-beta</ignoreVersion>\n"
+                + "    <ignoreVersion type=\"illegalType\">illegalVersion</ignoreVersion>\n"
+                + "  </ignoreVersions>\n"
+                + "  <rules>\n"
+                + "    <rule groupId=\"com.mycompany.maven\">\n"
+                + "      <ignoreVersions>\n"
+                + "        <ignoreVersion>one</ignoreVersion>\n"
+                + "        <ignoreVersion>two</ignoreVersion>\n"
+                + "        <ignoreVersion>1.2.0</ignoreVersion>\n"
+                + "        <ignoreVersion type=\"illegalType\">illegalVersion</ignoreVersion>\n"
+                + "      </ignoreVersions>\n"
+                + "    </rule>\n"
+                + "  </rules>\n"
+                + "</ruleset>";
+    }
+
+    protected UseLatestVersionsMojoBase createMojo() throws IllegalAccessException, MojoExecutionException {
+        AtomicBoolean inUse = new AtomicBoolean(false);
+        Wagon testWagon = new TestWagonStub(file -> {
+            try {
+                assertThat("Resource is in use", inUse.compareAndSet(false, true), is(true));
+                Files.write(file.toPath(), getRulesString().getBytes(StandardCharsets.UTF_8));
+                Thread.sleep(200);
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                inUse.set(false);
+            }
+        });
+        return new UseLatestVersionsMojo(
+                artifactFactory,
+                MockUtils.mockAetherRepositorySystem(),
+                Collections.singletonMap("proto", testWagon),
+                changeRecorder.asTestMap()) {
+            {
+                reactorProjects = emptyList();
+                MavenProject project = new MavenProject() {
+                    {
+                        setModel(new Model() {
+                            {
+                                setGroupId("default-group");
+                                setArtifactId("project-artifact");
+                                setVersion("1.0.0-SNAPSHOT");
+
+                                setDependencies(Arrays.asList(
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("artifactA")
+                                                .withVersion("1.0.0")
+                                                .withType("pom")
+                                                .withClassifier("default")
+                                                .withScope(SCOPE_COMPILE)
+                                                .build(),
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("artifactB")
+                                                .withVersion("1.0.0")
+                                                .withType("pom")
+                                                .withClassifier("default")
+                                                .withScope(SCOPE_COMPILE)
+                                                .build(),
+                                        DependencyBuilder.newBuilder()
+                                                .withGroupId("default-group")
+                                                .withArtifactId("artifactC")
+                                                .withVersion("1.0.0")
+                                                .withType("pom")
+                                                .withClassifier("default")
+                                                .withScope(SCOPE_COMPILE)
+                                                .build()));
+                            }
+                        });
+                    }
+                };
+                setProject(project);
+                session = mockMavenSession();
+                setVariableValueToObject(this, "rulesUri", "proto://localhost/rules.xml");
+            }
+        };
+    }
+
+    @Test
+    public void testConcurrency() throws Exception {
+        try (MockedStatic<PomHelper> pomHelper = mockStatic(PomHelper.class)) {
+            pomHelper
+                    .when(() -> PomHelper.setDependencyVersion(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(true);
+            pomHelper
+                    .when(() -> PomHelper.getRawModel(any(MavenProject.class)))
+                    .thenReturn(mojo.getProject().getModel());
+            pomHelper
+                    .when(() -> PomHelper.setProjectParentVersion(any(), anyString()))
+                    .thenReturn(true);
+            mojo.update(null);
+        }
+
+        assertThat(
+                changeRecorder.getChanges(),
+                allOf(
+                        hasItem(new DefaultDependencyVersionChange(
+                                "default-group", "artifactA",
+                                "1.0.0", "2.0.0")),
+                        hasItem(new DefaultDependencyVersionChange(
+                                "default-group", "artifactB",
+                                "1.0.0", "1.1.0"))));
+    }
+}

--- a/versions-test/src/main/java/org/codehaus/mojo/versions/utils/MockUtils.java
+++ b/versions-test/src/main/java/org/codehaus/mojo/versions/utils/MockUtils.java
@@ -32,6 +32,9 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.i18n.I18N;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.AuthenticationSelector;
+import org.eclipse.aether.repository.MirrorSelector;
+import org.eclipse.aether.repository.ProxySelector;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -183,11 +186,18 @@ public class MockUtils {
      */
     public static MavenSession mockMavenSession(MavenProject project) {
         MavenSession session = mock(MavenSession.class);
-        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        RepositorySystemSession repositorySystemSession = mock(RepositorySystemSession.class);
+        when(session.getRepositorySession()).thenReturn(repositorySystemSession);
         when(session.getCurrentProject()).thenReturn(project);
         Properties emptyProperties = new Properties();
         when(session.getUserProperties()).thenReturn(emptyProperties);
         when(session.getSystemProperties()).thenReturn(emptyProperties);
+        ProxySelector proxySelector = mock(ProxySelector.class);
+        when(repositorySystemSession.getProxySelector()).thenReturn(proxySelector);
+        AuthenticationSelector authenticationSelector = mock(AuthenticationSelector.class);
+        when(repositorySystemSession.getAuthenticationSelector()).thenReturn(authenticationSelector);
+        MirrorSelector mirrorSelector = mock(MirrorSelector.class);
+        when(repositorySystemSession.getMirrorSelector()).thenReturn(mirrorSelector);
         return session;
     }
 }


### PR DESCRIPTION
Refactoring jobs in 2.19.0 caused a race condition when creating VersionHelper and its companion RuleServiceBuilder. In some cases, this will cause a race condition when attempting the rules file retrieval (multiple threads per dependencies will create a new VersionHelper and a new RulesServiceBuilder). "Oopsie woopsie" indeed.

@slawekjaranowski please review. Thanks.