### PR TITLE
Artifact comparison should use semantic version comparison.

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/DependencyComparator.java
@@ -40,7 +40,6 @@ public enum DependencyComparator implements Comparator<Dependency> {
      * @see java.util.Comparator#compare(Object, Object)
      * @since 1.0-alpha-1
      */
-    @SuppressWarnings("checkstyle:InnerAssignment")
     public int compare(Dependency d1, Dependency d2) {
         return d1 == d2
                 ? 0
@@ -49,8 +48,7 @@ public enum DependencyComparator implements Comparator<Dependency> {
                                         dep -> ofNullable(dep.getArtifactId()).orElse(""))
                                 .thenComparing(
                                         dep -> ofNullable(dep.getClassifier()).orElse(""))
-                                .thenComparing(
-                                        dep -> ofNullable(dep.getVersion()).orElse("")))
+                                .thenComparing(Dependency::getVersion, VersionStringComparator.STRICT))
                         .compare(d1, d2);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PluginComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PluginComparator.java
@@ -36,6 +36,24 @@ public enum PluginComparator implements Comparator<Object> {
         return o instanceof Plugin || o instanceof ReportPlugin;
     }
 
+    private static String getGroupId(Object o) {
+        return o instanceof Plugin
+                ? ((Plugin) o).getGroupId()
+                : o instanceof ReportPlugin ? ((ReportPlugin) o).getGroupId() : "";
+    }
+
+    private static String getArtifactId(Object o) {
+        return o instanceof Plugin
+                ? ((Plugin) o).getArtifactId()
+                : o instanceof ReportPlugin ? ((ReportPlugin) o).getArtifactId() : "";
+    }
+
+    private static String getVersion(Object o) {
+        return o instanceof Plugin
+                ? ((Plugin) o).getVersion()
+                : o instanceof ReportPlugin ? ((ReportPlugin) o).getVersion() : "";
+    }
+
     /**
      * Compares to {@link Plugin} or {@link ReportPlugin} instances.
      *
@@ -51,27 +69,12 @@ public enum PluginComparator implements Comparator<Object> {
                     "This comparator can only be used to compare Plugin and ReportPlugin instances");
         }
 
-        String g1 = o1 instanceof Plugin ? ((Plugin) o1).getGroupId() : ((ReportPlugin) o1).getGroupId();
-        String g2 = o2 instanceof Plugin ? ((Plugin) o2).getGroupId() : ((ReportPlugin) o2).getGroupId();
-
-        int r = g1.compareTo(g2);
-        if (r == 0) {
-            String a1 = o1 instanceof Plugin ? ((Plugin) o1).getArtifactId() : ((ReportPlugin) o1).getArtifactId();
-            String a2 = o2 instanceof Plugin ? ((Plugin) o2).getArtifactId() : ((ReportPlugin) o2).getArtifactId();
-            r = a1.compareTo(a2);
+        if (o1 == o2) {
+            return 0;
         }
-        if (r == 0) {
-            String v1 = o1 instanceof Plugin ? ((Plugin) o1).getVersion() : ((ReportPlugin) o1).getVersion();
-            String v2 = o2 instanceof Plugin ? ((Plugin) o2).getVersion() : ((ReportPlugin) o2).getVersion();
-            if (v1 == null) {
-                // hope I got the +1/-1 the right way around
-                return v2 == null ? 0 : -1;
-            }
-            if (v2 == null) {
-                return 1;
-            }
-            r = v1.compareTo(v2);
-        }
-        return r;
+        return Comparator.nullsLast(Comparator.comparing(PluginComparator::getGroupId)
+                        .thenComparing(PluginComparator::getArtifactId)
+                        .thenComparing(PluginComparator::getVersion, VersionStringComparator.STRICT))
+                .compare(o1, o2);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PropertyComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PropertyComparator.java
@@ -21,7 +21,6 @@ package org.codehaus.mojo.versions.utils;
 
 import java.util.Comparator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.codehaus.mojo.versions.api.Property;
 
 /**
@@ -41,17 +40,9 @@ public enum PropertyComparator implements Comparator<Property> {
      * @see java.util.Comparator#compare(Object, Object)
      * @since 1.0-beta-1
      */
-    @SuppressWarnings("checkstyle:InnerAssignment")
     public int compare(Property p1, Property p2) {
-        int r;
-        return p1 == p2
-                ? 0
-                : p1 == null
-                        ? 1
-                        : p2 == null
-                                ? -1
-                                : (r = StringUtils.compare(p1.getName(), p2.getName())) == 0
-                                        ? StringUtils.compare(p1.getValue(), p2.getValue())
-                                        : r;
+        return Comparator.nullsLast(Comparator.comparing(Property::getName)
+                        .thenComparing(Property::getValue, VersionStringComparator.LENIENT))
+                .compare(p1, p2);
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/VersionStringComparator.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/VersionStringComparator.java
@@ -1,0 +1,48 @@
+package org.codehaus.mojo.versions.utils;
+
+import java.util.Comparator;
+
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionScheme;
+
+public enum VersionStringComparator implements Comparator<String> {
+    STRICT(false),
+    LENIENT(true);
+
+    private final boolean lenient;
+
+    VersionStringComparator(boolean lenient) {
+        this.lenient = lenient;
+    }
+
+    private static final VersionScheme VERSION_SCHEME;
+
+    private static final Version NULL_VERSION;
+
+    static {
+        VERSION_SCHEME = new GenericVersionScheme();
+        try {
+            NULL_VERSION = VERSION_SCHEME.parseVersion("0");
+        } catch (InvalidVersionSpecificationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private Version extractVersion(String v) {
+        try {
+            return VERSION_SCHEME.parseVersion(v);
+        } catch (InvalidVersionSpecificationException e) {
+            if (lenient) {
+                return NULL_VERSION;
+            }
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public int compare(String s1, String s2) {
+        return Comparator.nullsLast(Comparator.comparing(this::extractVersion)).compare(s1, s2);
+    }
+}

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/utils/DependencyComparatorTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/utils/DependencyComparatorTest.java
@@ -1,0 +1,131 @@
+package org.codehaus.mojo.versions.utils;
+
+import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+class DependencyComparatorTest {
+
+    private Dependency dep(String groupId, String artifactId, String version) {
+        return DependencyBuilder.newBuilder()
+                .withGroupId(groupId)
+                .withArtifactId(artifactId)
+                .withVersion(version)
+                .build();
+    }
+
+    @Test
+    void comparesByGroupIdThenArtifactIdThenVersion() {
+        Dependency a1 = dep("a.group", "artifact", "1.0");
+        Dependency b1 = dep("b.group", "artifact", "1.0");
+
+        assertThat(DependencyComparator.INSTANCE.compare(a1, b1), lessThan(0));
+        assertThat(DependencyComparator.INSTANCE.compare(b1, a1), greaterThan(0));
+    }
+
+    @Test
+    void comparesByArtifactIdWhenGroupIdEqual() {
+        Dependency a1 = dep("g", "a", "1.0");
+        Dependency b1 = dep("g", "b", "1.0");
+
+        assertThat(DependencyComparator.INSTANCE.compare(a1, b1), lessThan(0));
+    }
+
+    @Test
+    void comparesByVersionWhenGroupAndArtifactEqual() {
+        Dependency v1 = dep("g", "a", "1.0");
+        Dependency v2 = dep("g", "a", "2.0");
+
+        assertThat(DependencyComparator.INSTANCE.compare(v1, v2), lessThan(0));
+    }
+
+    @Test
+    void nullDependenciesAreHandled() {
+        Dependency d = dep("g", "a", "1.0");
+        assertThat(DependencyComparator.INSTANCE.compare(null, d), greaterThan(0));
+        assertThat(DependencyComparator.INSTANCE.compare(d, null), lessThan(0));
+        assertThat(DependencyComparator.INSTANCE.compare(null, null), is(0));
+    }
+
+    @Test
+    void numericVersionsCompareSemanticallyNotLexicographically() {
+        Dependency v2 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("2")
+                .build();
+        Dependency v10 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("10")
+                .build();
+
+        // Semantic: 2 < 10
+        assertThat(DependencyComparator.INSTANCE.compare(v2, v10), lessThan(0));
+        // Lexicographic would wrongly say "10" < "2"
+    }
+
+    @Test
+    void patchVersionsCompareSemanticallyNotLexicographically() {
+        Dependency v102 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0.2")
+                .build();
+        Dependency v1010 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0.10")
+                .build();
+
+        // Semantic: 1.0.2 < 1.0.10
+        assertThat(DependencyComparator.INSTANCE.compare(v102, v1010), lessThan(0));
+        // Lexicographic would wrongly say "1.0.10" < "1.0.2"
+    }
+
+    @Test
+    void prereleaseIsLessThanRelease() {
+        Dependency alpha = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0.0-alpha")
+                .build();
+        Dependency release = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0.0")
+                .build();
+
+        // Semantic: alpha < release
+        assertThat(DependencyComparator.INSTANCE.compare(alpha, release), lessThan(0));
+        // Lexicographic would put "1.0.0-alpha" after "1.0.0"
+    }
+
+    @Test
+    void versionsWithDifferentPrecisionAreEquivalent() {
+        Dependency v1 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1")
+                .build();
+        Dependency v10 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0")
+                .build();
+        Dependency v100 = DependencyBuilder.newBuilder()
+                .withGroupId("g")
+                .withArtifactId("a")
+                .withVersion("1.0.0")
+                .build();
+
+        // All should compare as equal
+        assertThat(DependencyComparator.INSTANCE.compare(v1, v10), is(0));
+        assertThat(DependencyComparator.INSTANCE.compare(v10, v100), is(0));
+        assertThat(DependencyComparator.INSTANCE.compare(v1, v100), is(0));
+    }
+}

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/utils/PluginComparatorTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/utils/PluginComparatorTest.java
@@ -1,0 +1,117 @@
+package org.codehaus.mojo.versions.utils;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.ReportPlugin;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+class PluginComparatorTest {
+
+    private Plugin plugin(String groupId, String artifactId, String version) {
+        Plugin p = new Plugin();
+        p.setGroupId(groupId);
+        p.setArtifactId(artifactId);
+        p.setVersion(version);
+        return p;
+    }
+
+    private ReportPlugin reportPlugin(String groupId, String artifactId, String version) {
+        ReportPlugin rp = new ReportPlugin();
+        rp.setGroupId(groupId);
+        rp.setArtifactId(artifactId);
+        rp.setVersion(version);
+        return rp;
+    }
+
+    @Test
+    void comparesByGroupIdThenArtifactIdThenVersion() {
+        Plugin a = plugin("a.group", "artifact", "1.0");
+        Plugin b = plugin("b.group", "artifact", "1.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(a, b), lessThan(0));
+        assertThat(PluginComparator.INSTANCE.compare(b, a), greaterThan(0));
+    }
+
+    @Test
+    void comparesByArtifactIdWhenGroupIdEqual() {
+        Plugin a = plugin("g", "a", "1.0");
+        Plugin b = plugin("g", "b", "1.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(a, b), lessThan(0));
+    }
+
+    @Test
+    void comparesByVersionWhenGroupAndArtifactEqual() {
+        Plugin v1 = plugin("g", "a", "1.0");
+        Plugin v2 = plugin("g", "a", "2.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(v1, v2), lessThan(0));
+    }
+
+    @Test
+    void worksWithReportPluginAsWell() {
+        ReportPlugin rp1 = reportPlugin("g", "a", "1.0");
+        ReportPlugin rp2 = reportPlugin("g", "a", "2.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(rp1, rp2), lessThan(0));
+    }
+
+    @Test
+    void crossComparePluginAndReportPlugin() {
+        Plugin p = plugin("g", "a", "1.0");
+        ReportPlugin rp = reportPlugin("g", "a", "2.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(p, rp), lessThan(0));
+        assertThat(PluginComparator.INSTANCE.compare(rp, p), greaterThan(0));
+    }
+
+    @Test
+    void semanticComparisonDiffersFromLexicographicNumeric() {
+        Plugin v2 = plugin("g", "a", "2");
+        Plugin v10 = plugin("g", "a", "10");
+
+        // Semantic: 2 < 10
+        assertThat(PluginComparator.INSTANCE.compare(v2, v10), lessThan(0));
+    }
+
+    @Test
+    void semanticComparisonDiffersFromLexicographicPatch() {
+        Plugin v102 = plugin("g", "a", "1.0.2");
+        Plugin v1010 = plugin("g", "a", "1.0.10");
+
+        // Semantic: 1.0.2 < 1.0.10
+        assertThat(PluginComparator.INSTANCE.compare(v102, v1010), lessThan(0));
+    }
+
+    @Test
+    void versionsWithDifferentPrecisionAreEquivalent() {
+        Plugin v1 = plugin("g", "a", "1");
+        Plugin v10 = plugin("g", "a", "1.0");
+        Plugin v100 = plugin("g", "a", "1.0.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(v1, v10), is(0));
+        assertThat(PluginComparator.INSTANCE.compare(v10, v100), is(0));
+        assertThat(PluginComparator.INSTANCE.compare(v1, v100), is(0));
+    }
+
+    @Test
+    void prereleaseIsLessThanRelease() {
+        Plugin alpha = plugin("g", "a", "1.0.0-alpha");
+        Plugin release = plugin("g", "a", "1.0.0");
+
+        assertThat(PluginComparator.INSTANCE.compare(alpha, release), lessThan(0));
+    }
+
+    @Test
+    void throwsOnNonPluginObjects() {
+        Object notAPlugin = new Object();
+        Plugin p = plugin("g", "a", "1.0");
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class, () -> PluginComparator.INSTANCE.compare(notAPlugin, p));
+    }
+}


### PR DESCRIPTION
Now this is a "business" kind of bug and I am surprised that this hasn't come up before. Dependencies, Plugins, etc, all use regular lexicographic comparison to order versions (where this is done by the plugin and not Resolver) whereas it should use semantic versioning (for example `GenericVersion` from Resolver).

I guess this hasn't been noticed because most people don't have any strange versioning schemes, but I have added some unit tests which break with regular string comparison (e.g. `1.0` should be equivalent to `1.0.0`, etc.).

