### PR TITLE
Allow filtering out pre releases in use-latest-versions

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -59,6 +59,17 @@ public abstract class AbstractVersionDetails implements VersionDetails {
                     + "[-.]?(\\d{0,2}[a-z]?|\\d{6}\\.\\d{4})|\\d{8}(?:\\.?\\d{6})?)$");
 
     /**
+     * Checks if the given version string represents a pre-release version.
+     * Pre-release versions include alpha, beta, milestone, preview, and release candidate versions.
+     *
+     * @param version the version string to check
+     * @return true if the version is a pre-release version, false otherwise
+     */
+    public static boolean isPreReleaseVersion(String version) {
+        return version != null && PREVIEW_PATTERN.matcher(version).matches();
+    }
+
+    /**
      * Current version of the dependency artifact.
      *
      * @since 1.0-beta-1

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/AbstractVersionDetailsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/AbstractVersionDetailsTest.java
@@ -165,4 +165,50 @@ class AbstractVersionDetailsTest {
         instance.setCurrentVersionRange(VersionRange.createFromVersionSpec("[,0]"));
         assertThrows(NullPointerException.class, () -> instance.getSelectedRestriction(null));
     }
+
+    @Test
+    void testIsPreReleaseVersion() {
+        // Stable versions should not be pre-release
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0"), is(false));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("6.2.3"), is(false));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("6.2.4"), is(false));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("2.0.0"), is(false));
+
+        // Alpha versions
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-alpha"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-alpha1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-alpha12"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-ALPHA"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-a"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-a1"), is(true));
+
+        // Beta versions
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-beta"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-beta1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-BETA"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-b"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-b1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("2.0.0-beta"), is(true));
+
+        // Milestone versions
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-M1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-M2"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("7.0.0-M3"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-milestone"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-milestone1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-m"), is(true));
+
+        // Release candidate versions
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-rc"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-rc1"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-RC"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-RC1"), is(true));
+
+        // Preview versions
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-preview"), is(true));
+        assertThat(AbstractVersionDetails.isPreReleaseVersion("1.0.0-PREVIEW"), is(true));
+
+        // Null should return false
+        assertThat(AbstractVersionDetails.isPreReleaseVersion(null), is(false));
+    }
 }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.wagon.Wagon;
+import org.codehaus.mojo.versions.api.AbstractVersionDetails;
 import org.codehaus.mojo.versions.api.recording.ChangeRecorder;
 import org.codehaus.mojo.versions.utils.ArtifactFactory;
 import org.eclipse.aether.RepositorySystem;
@@ -84,6 +85,13 @@ public class UseLatestVersionsMojo extends UseLatestVersionsMojoBase {
      */
     @Parameter(property = "allowSnapshots", defaultValue = "false")
     protected boolean allowSnapshots;
+
+    /**
+     * Whether to allow pre-release versions (alpha, beta, milestone, rc) when searching
+     * for the latest version of an artifact.
+     */
+    @Parameter(property = "allowPreReleases", defaultValue = "false")
+    protected boolean allowPreReleases = false;
 
     /**
      * Whether to process the dependencies section of the project.
@@ -168,6 +176,9 @@ public class UseLatestVersionsMojo extends UseLatestVersionsMojoBase {
 
     @Override
     protected boolean artifactVersionsFilter(ArtifactVersion ver) {
+        if (!allowPreReleases) {
+            return !AbstractVersionDetails.isPreReleaseVersion(ver.toString());
+        }
         return true;
     }
 


### PR DESCRIPTION
Adds a new allowPreReleases parameter (defaulting to false) to the use-latest-versions goal to prevent upgrading to pre-release versions (alpha, beta, milestone, rc).

Fixes #1225