### PR TITLE
Fixes #1295: getAllUpdates(boolean) should respect currentVersionRange

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -337,7 +337,16 @@ public abstract class AbstractVersionDetails implements VersionDetails {
 
     @Override
     public final ArtifactVersion[] getAllUpdates(boolean includeSnapshots) {
-        return getAllUpdates((VersionRange) null, includeSnapshots);
+        ArtifactVersion[] updates = getAllUpdates((VersionRange) null, includeSnapshots);
+        if (getCurrentVersion() == null) {
+            ArtifactVersion lowerBound = getHighestLowerBound(null);
+            return Arrays.stream(updates)
+                    .filter(v -> !getCurrentVersionRange().containsVersion(v))
+                    .filter(v -> v.compareTo(lowerBound) > 0)
+                    .toArray(ArtifactVersion[]::new);
+        } else {
+            return updates;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes this small bug.

It's currently used in DisplayDependencyUpdates, but the bug does not affect performance of the plugin whatsoever: DisplayDependencyUpdates filters all versions once again after retrieving all updates.

@slawekjaranowski because of that, I thought of maybe making all plugins just use the Resolver, or a thin wrapper on it, to retrieve all versions, and then use `ArtifactVersions` to filter them once they are retrieved. That will make it much more clear. Currently, there's so many of different `getDependencyUpdates` variants in `VersionsHelper`, which just make the whole architecture messy. That in a different PR.