### PR TITLE
Fixed a problem with dependency management filtering in the logged results

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojo.java
@@ -352,27 +352,26 @@ public class DisplayDependencyUpdatesMojo extends AbstractVersionsDisplayMojo {
      * @return true if the dependencies match, false otherwise
      */
     // open for tests
-    protected static boolean dependenciesMatch(Dependency dependency, Dependency managedDependency) {
-        if (!managedDependency.getGroupId().equals(dependency.getGroupId())) {
+    static boolean dependenciesMatch(Dependency dependency, Dependency managedDependency) {
+        if (!Objects.equals(managedDependency.getGroupId(), dependency.getGroupId())) {
             return false;
         }
 
-        if (!managedDependency.getArtifactId().equals(dependency.getArtifactId())) {
+        if (!Objects.equals(managedDependency.getArtifactId(), dependency.getArtifactId())) {
             return false;
         }
 
-        if (managedDependency.getScope() == null
-                || Objects.equals(managedDependency.getScope(), dependency.getScope())) {
+        if (managedDependency.getScope() != null
+                && !Objects.equals(managedDependency.getScope(), dependency.getScope())) {
             return false;
         }
 
-        if (managedDependency.getClassifier() == null
-                || Objects.equals(managedDependency.getClassifier(), dependency.getClassifier())) {
+        if (managedDependency.getClassifier() != null
+                && !Objects.equals(managedDependency.getClassifier(), dependency.getClassifier())) {
             return false;
         }
 
-        return dependency.getVersion() == null
-                || managedDependency.getVersion() == null
+        return managedDependency.getVersion() == null
                 || Objects.equals(managedDependency.getVersion(), dependency.getVersion());
     }
 

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayDependencyUpdatesMojoTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
 import org.apache.maven.model.Model;
@@ -667,5 +668,37 @@ public class DisplayDependencyUpdatesMojoTest extends AbstractMojoTestCase {
                             .count(),
                     is(overwrite ? 1L : 2L));
         }
+    }
+
+    private static Dependency createManagedDependency(
+            Dependency prototype, String version, String scope, String classifier) {
+        return DependencyBuilder.newBuilder()
+                .withGroupId(prototype.getGroupId())
+                .withArtifactId(prototype.getArtifactId())
+                .withVersion(version)
+                .withScope(scope)
+                .withClassifier(classifier)
+                .build();
+    }
+
+    public void testDependenciesMatchTestScope() {
+        Dependency dependency = DependencyBuilder.newBuilder()
+                .withGroupId("default-group")
+                .withArtifactId("default-artifact")
+                .withVersion("1.0.0")
+                .withScope("compile")
+                .withClassifier("sources")
+                .build();
+
+        assertTrue(DisplayDependencyUpdatesMojo.dependenciesMatch(
+                dependency, createManagedDependency(dependency, null, null, null)));
+        assertTrue(DisplayDependencyUpdatesMojo.dependenciesMatch(
+                dependency, createManagedDependency(dependency, "1.0.0", null, null)));
+        assertTrue(DisplayDependencyUpdatesMojo.dependenciesMatch(
+                dependency, createManagedDependency(dependency, null, "compile", null)));
+        assertTrue(DisplayDependencyUpdatesMojo.dependenciesMatch(
+                dependency, createManagedDependency(dependency, null, null, "sources")));
+        assertTrue(DisplayDependencyUpdatesMojo.dependenciesMatch(
+                dependency, createManagedDependency(dependency, null, null, "sources")));
     }
 }


### PR DESCRIPTION
DisplayDependencyManagement should only show updates for dependency management entries, if these are not present in dependencies: it uses `dependenciesMatch` to filter those. However, the function was not correct: it should treat no values in dependency management as "wildcards" and not try matching nulls against dependency values.

Fixed that. A minor issue.

Edit: Copilot review is not entirely correct. There were no problems with NPE with this bug, it's rather that the matching was incorrect. It should treat not defined fields in dependency management as wildcards rather than match nulls with dependencies.