### PR TITLE
ResolverAdapter: a thin adapter over Resolver

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/IgnoreVersionHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/IgnoreVersionHelper.java
@@ -16,12 +16,11 @@ package org.codehaus.mojo.versions.api;
  */
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
@@ -44,16 +43,40 @@ public class IgnoreVersionHelper {
     /**
      * Provides an instance of a list of valid types of {@link IgnoreVersion}
      */
-    public static final List<String> VALID_TYPES = Collections.unmodifiableList(
-            Arrays.asList(IgnoreVersion.TYPE_EXACT, IgnoreVersion.TYPE_REGEX, IgnoreVersion.TYPE_RANGE));
+    public static final List<String> VALID_TYPES = Arrays.stream(IgnoreVersionType.values())
+            .map(IgnoreVersionType::getType)
+            .collect(Collectors.toList());
 
-    private static final Map<String, BiFunction<Version, IgnoreVersion, Boolean>> VERSION_MATCHERS;
+    public enum IgnoreVersionType {
+        TYPE_EXACT(IgnoreVersion.TYPE_EXACT, IgnoreVersionHelper::isVersionIgnoredExact),
+        TYPE_REGEX(IgnoreVersion.TYPE_REGEX, IgnoreVersionHelper::isVersionIgnoredRegex),
+        TYPE_RANGE(IgnoreVersion.TYPE_RANGE, IgnoreVersionHelper::isVersionIgnoredRange);
 
-    static {
-        VERSION_MATCHERS = new HashMap<>();
-        VERSION_MATCHERS.put(IgnoreVersion.TYPE_EXACT, IgnoreVersionHelper::isVersionIgnoredExact);
-        VERSION_MATCHERS.put(IgnoreVersion.TYPE_REGEX, IgnoreVersionHelper::isVersionIgnoredRegex);
-        VERSION_MATCHERS.put(IgnoreVersion.TYPE_RANGE, IgnoreVersionHelper::isVersionIgnoredRange);
+        private final String type;
+
+        private final BiFunction<String, IgnoreVersion, Boolean> predicate;
+
+        IgnoreVersionType(String type, BiFunction<String, IgnoreVersion, Boolean> predicate) {
+            this.type = type;
+            this.predicate = predicate;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public BiFunction<String, IgnoreVersion, Boolean> getPredicate() {
+            return predicate;
+        }
+
+        public static Optional<IgnoreVersionType> forType(String type) {
+            for (IgnoreVersionType v : IgnoreVersionType.values()) {
+                if (v.getType().equals(type)) {
+                    return Optional.of(v);
+                }
+            }
+            return Optional.empty();
+        }
     }
 
     private IgnoreVersionHelper() {}
@@ -65,33 +88,44 @@ public class IgnoreVersionHelper {
      * @return {@code true} if type is valid
      */
     public static boolean isValidType(IgnoreVersion ignoreVersion) {
-        return VALID_TYPES.contains(ignoreVersion.getType());
+        return IgnoreVersionType.forType(ignoreVersion.getType()).isPresent();
     }
 
     /**
      * Check if the provided version is ignored by the provided {@link IgnoreVersion} instance
      *
-     * @param version version to be checked
+     * @param v version string to be checked
      * @param ignoreVersion {@link IgnoreVersion} instance providing the filter
      * @return {@code true} if the provided version is ignored
      */
-    public static boolean isVersionIgnored(Version version, IgnoreVersion ignoreVersion) {
-        return VERSION_MATCHERS.get(ignoreVersion.getType()).apply(version, ignoreVersion);
+    public static boolean isVersionIgnored(String v, IgnoreVersion ignoreVersion) {
+        return IgnoreVersionType.forType(ignoreVersion.getType())
+                .map(t -> t.getPredicate().apply(v, ignoreVersion))
+                .orElseThrow(() -> new IllegalArgumentException("Invalid version type: " + ignoreVersion.getType()));
     }
 
-    private static boolean isVersionIgnoredExact(Version version, IgnoreVersion ignoreVersion) {
-        return ignoreVersion.getVersion().equals(version.toString());
+    /**
+     * Check if the provided version is ignored by the provided {@link IgnoreVersion} instance
+     *
+     * @param v version string to be checked
+     * @param ignoreVersion {@link IgnoreVersion} instance providing the filter
+     * @return {@code true} if the provided version is ignored
+     */
+    public static boolean isVersionIgnored(Version v, IgnoreVersion ignoreVersion) {
+        return isVersionIgnored(v.toString(), ignoreVersion);
     }
 
-    private static boolean isVersionIgnoredRegex(Version version, IgnoreVersion ignoreVersion) {
-        return Pattern.compile(ignoreVersion.getVersion())
-                .matcher(version.toString())
-                .matches();
+    private static boolean isVersionIgnoredExact(String v, IgnoreVersion ignoreVersion) {
+        return ignoreVersion.getVersion().equals(v);
     }
 
-    private static boolean isVersionIgnoredRange(Version version, IgnoreVersion ignoreVersion) {
+    private static boolean isVersionIgnoredRegex(String v, IgnoreVersion ignoreVersion) {
+        return Pattern.compile(ignoreVersion.getVersion()).matcher(v).matches();
+    }
+
+    private static boolean isVersionIgnoredRange(String v, IgnoreVersion ignoreVersion) {
         try {
-            ArtifactVersion aVersion = ArtifactVersionService.getArtifactVersion(version.toString());
+            ArtifactVersion aVersion = ArtifactVersionService.getArtifactVersion(v);
             VersionRange versionRange = VersionRange.createFromVersionSpec(ignoreVersion.getVersion());
             if (versionRange.hasRestrictions()) {
                 return versionRange.containsVersion(aVersion);

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/PomHelper.java
@@ -803,7 +803,7 @@ public class PomHelper {
     /**
      * Examines the project to find any properties which are associated with versions of artifacts in the project.
      *
-     * @param helper        {@link VersionsHelper} instance
+     * @param resolverAdapter        {@link ResolverAdapter} instance
      * @param log           {@link Log} instance
      * @param project       The project to examine.
      * @param includeParent whether parent POMs should be included
@@ -813,7 +813,7 @@ public class PomHelper {
      * @since 1.0-alpha-3
      */
     public PropertyVersionsBuilder[] getPropertyVersionsBuilders(
-            VersionsHelper helper, Log log, MavenProject project, boolean includeParent)
+            ResolverAdapter resolverAdapter, Log log, MavenProject project, boolean includeParent)
             throws ExpressionEvaluationException, IOException {
 
         Map<MavenProject, Model> reactorModels = includeParent
@@ -825,8 +825,8 @@ public class PomHelper {
 
         Map<String, PropertyVersionsBuilder> propertiesMap = new TreeMap<>();
         reactorModels.values().forEach(model -> {
-            processProfiles(helper, log, propertiesMap, model, activeProfileIds);
-            putPropertiesIfAbsent(helper, log, propertiesMap, null, model.getProperties());
+            processProfiles(resolverAdapter, log, propertiesMap, model, activeProfileIds);
+            putPropertiesIfAbsent(resolverAdapter, log, propertiesMap, null, model.getProperties());
         });
 
         // Process the project and its parent hierarchy
@@ -847,7 +847,7 @@ public class PomHelper {
     }
 
     private void processProfiles(
-            VersionsHelper helper,
+            ResolverAdapter resolverAdapter,
             Log log,
             Map<String, PropertyVersionsBuilder> propertiesMap,
             Model model,
@@ -857,7 +857,8 @@ public class PomHelper {
                 .filter(profile -> activeProfileIds.contains(profile.getId()))
                 .forEach(profile -> {
                     try {
-                        putPropertiesIfAbsent(helper, log, propertiesMap, profile.getId(), profile.getProperties());
+                        putPropertiesIfAbsent(
+                                resolverAdapter, log, propertiesMap, profile.getId(), profile.getProperties());
                         processDependencies(
                                 propertiesMap, profile.getDependencyManagement(), profile.getDependencies());
                         processBuild(propertiesMap, profile.getBuild());
@@ -1076,7 +1077,7 @@ public class PomHelper {
     }
 
     private void putPropertiesIfAbsent(
-            VersionsHelper helper,
+            ResolverAdapter resolverAdapter,
             Log log,
             Map<String, PropertyVersionsBuilder> result,
             String profileId,
@@ -1084,7 +1085,7 @@ public class PomHelper {
         ofNullable(properties)
                 .map(Properties::stringPropertyNames)
                 .ifPresent(propertyNames -> propertyNames.forEach(propertyName -> result.putIfAbsent(
-                        propertyName, new PropertyVersionsBuilder(helper, profileId, propertyName, log))));
+                        propertyName, new PropertyVersionsBuilder(resolverAdapter, profileId, propertyName, log))));
     }
 
     /**

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ResolverAdapter.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ResolverAdapter.java
@@ -1,0 +1,90 @@
+package org.codehaus.mojo.versions.api;
+
+import java.util.Collection;
+import java.util.SortedMap;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+
+/**
+ * A thin adapter over {@link org.eclipse.aether.RepositorySystem} to help
+ * discover available versions for provided artifacts.
+ *
+ * @since 2.20.0
+ */
+public interface ResolverAdapter {
+
+    /**
+     * Attempts to resolve the artifact. If the artifact cannot be resolved, an
+     * {@link ArtifactResolutionException} is thrown.
+     *
+     * @param artifact              The artifact to resolve.
+     * @param usePluginRepositories whether to resolve from the plugin repositories or the regular repositories.
+     * @throws ArtifactResolutionException if resolution is unsuccessful
+     * @since 2.20.0
+     */
+    void resolveArtifact(Artifact artifact, boolean usePluginRepositories) throws ArtifactResolutionException;
+
+    /**
+     * Returns all available versions of the specified artifact that are available in either the local repository, or
+     * the
+     * appropriate remote repositories.
+     * <b>The resulting {@link ArtifactVersions} instance will contain all versions, including snapshots,
+     * regardless of the version range specified in the artifact.</b>
+     *
+     * @param artifact               The artifact to look for versions of.
+     * @param usePluginRepositories  {@code true} will consult the pluginRepositories
+     * @param useProjectRepositories {@code true} will consult regular project repositories
+     * @return The details of the available artifact versions.
+     * @throws VersionRetrievalException thrown if version resolution fails
+     * @since 2.15.0
+     */
+    ArtifactVersions resolveArtifactVersions(
+            Artifact artifact, boolean usePluginRepositories, boolean useProjectRepositories)
+            throws VersionRetrievalException;
+
+    /**
+     * <p>Returns a sorted map of all possible updates per dependency. The map keys are sorted using
+     * {@link org.codehaus.mojo.versions.utils.DependencyComparator}, which boils down to sorting by
+     * and groupId:artifactId:classifier.</p>
+     * <p>The returned map is sorted by {@code groupId:artifactId:classifier}.</p>
+     * <p>Version retrieval is done in parallel, using {@code LOOKUP_PARALLEL_THREADS} threads.</p>
+     *
+     * @param dependencies           a collection of {@link Dependency} instances to look up.
+     * @param usePluginRepositories  {@code true} will consult the pluginRepositories
+     * @param useProjectRepositories {@code true} will consult regular project repositories
+     * @return map containing the ArtifactVersions object per dependency sorted by groupId, artifactId,
+     *         classifier
+     * @throws VersionRetrievalException thrown if a version cannot be retrieved
+     */
+    SortedMap<Dependency, ArtifactVersions> resolveDependencyVersions(
+            Collection<Dependency> dependencies, boolean usePluginRepositories, boolean useProjectRepositories)
+            throws VersionRetrievalException;
+
+    /**
+     * Looks up the updates for a plugin. The resulting {@link org.codehaus.mojo.versions.api.PluginUpdatesDetails}
+     * instance will only contain versions that are newer than the current version of the plugin.
+     *
+     * @param plugin         The {@link Plugin} instance to look up.
+     * @return The plugin update details.
+     * @throws VersionRetrievalException thrown if version resolution fails
+     * @since 1.0-beta-1
+     */
+    PluginUpdatesDetails resolvePluginVersions(Plugin plugin) throws VersionRetrievalException;
+
+    /**
+     * <p>Looks up the updates for a set of plugins. The resulting
+     * {@link org.codehaus.mojo.versions.api.PluginUpdatesDetails} instance per plugin
+     * will only contain versions that are newer than the current version of the plugin.</p>
+     * <p>The returned map is sorted by {@code groupId:artifactId:classifier}.</p>
+     *
+     * @param plugins        A collection of {@link Plugin} instances to look up.
+     * @return A map, keyed by plugin, with values of type {@link org.codehaus.mojo.versions.api.PluginUpdatesDetails}.
+     * @throws VersionRetrievalException thrown if version resolution fails
+     * @since 1.0-beta-1
+     */
+    SortedMap<Plugin, PluginUpdatesDetails> resolvePluginVersions(Collection<Plugin> plugins)
+            throws VersionRetrievalException;
+}

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/VersionsHelper.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.versions.api;
  * under the License.
  */
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -37,7 +38,7 @@ import org.apache.maven.project.MavenProject;
  * @author Stephen Connolly
  * @since 1.0-alpha-3
  */
-public interface VersionsHelper {
+public interface VersionsHelper extends ResolverAdapter {
 
     /**
      * Looks up the versions of the specified artifact that are available in either the local repository, or the
@@ -196,7 +197,7 @@ public interface VersionsHelper {
     class VersionPropertiesMapRequest {
         private MavenProject mavenProject;
 
-        private Property[] propertyDefinitions;
+        private List<Property> propertyDefinitions;
 
         private String includeProperties;
 
@@ -229,7 +230,7 @@ public interface VersionsHelper {
          *
          * @return {@link Property} array
          */
-        protected Property[] getPropertyDefinitions() {
+        protected List<Property> getPropertyDefinitions() {
             return propertyDefinitions;
         }
 
@@ -281,11 +282,6 @@ public interface VersionsHelper {
         }
 
         /**
-         * Returns a new {@link Builder} instance
-         *
-         * @return new {@link Builder} instance
-         */
-        /**
          * Create a new builder instance.
          *
          * @return a fresh {@link Builder}
@@ -300,7 +296,7 @@ public interface VersionsHelper {
         public static class Builder {
             private MavenProject mavenProject;
 
-            private Property[] propertyDefinitions;
+            private List<Property> propertyDefinitions;
 
             private String includeProperties;
 
@@ -331,7 +327,7 @@ public interface VersionsHelper {
              * @param propertyDefinitions array of property definitions
              * @return {@link Builder} instance
              */
-            public Builder withPropertyDefinitions(Property[] propertyDefinitions) {
+            public Builder withPropertyDefinitions(List<Property> propertyDefinitions) {
                 this.propertyDefinitions = propertyDefinitions;
                 return this;
             }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/internal/DefaultResolverAdapter.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/internal/DefaultResolverAdapter.java
@@ -1,0 +1,230 @@
+package org.codehaus.mojo.versions.api.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.PluginUpdatesDetails;
+import org.codehaus.mojo.versions.api.ResolverAdapter;
+import org.codehaus.mojo.versions.api.VersionRetrievalException;
+import org.codehaus.mojo.versions.utils.ArtifactFactory;
+import org.codehaus.mojo.versions.utils.ArtifactVersionService;
+import org.codehaus.mojo.versions.utils.DependencyComparator;
+import org.codehaus.mojo.versions.utils.PluginComparator;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+
+import static java.util.Optional.of;
+import static org.apache.maven.RepositoryUtils.toArtifact;
+
+public class DefaultResolverAdapter implements ResolverAdapter {
+
+    private static final int LOOKUP_PARALLEL_THREADS = 12;
+
+    private final ArtifactFactory artifactFactory;
+
+    private final RepositorySystem repositorySystem;
+
+    private final Log log;
+
+    private final MavenSession mavenSession;
+
+    private final List<RemoteRepository> remotePluginRepositories;
+
+    private final List<RemoteRepository> remoteProjectRepositories;
+
+    public DefaultResolverAdapter(
+            ArtifactFactory artifactFactory, RepositorySystem repositorySystem, Log log, MavenSession mavenSession) {
+        this.artifactFactory = artifactFactory;
+        this.repositorySystem = repositorySystem;
+        this.log = log;
+        this.mavenSession = mavenSession;
+
+        this.remoteProjectRepositories = of(mavenSession)
+                .map(MavenSession::getCurrentProject)
+                .map(MavenProject::getRemoteProjectRepositories)
+                .map(this::forceDailyRemoteRepositoriesRefreshPolicy)
+                .orElseGet(Collections::emptyList);
+
+        this.remotePluginRepositories = of(mavenSession)
+                .map(MavenSession::getCurrentProject)
+                .map(MavenProject::getRemotePluginRepositories)
+                .map(this::forceDailyRemoteRepositoriesRefreshPolicy)
+                .orElseGet(Collections::emptyList);
+    }
+
+    private List<RemoteRepository> forceDailyRemoteRepositoriesRefreshPolicy(
+            List<RemoteRepository> remoteRepositories) {
+        return remoteRepositories.stream()
+                .map(remoteRepository -> {
+                    RepositoryPolicy snapshotPolicy = forceDailyUpdatePolicy(remoteRepository.getPolicy(true));
+                    RepositoryPolicy releasePolicy = forceDailyUpdatePolicy(remoteRepository.getPolicy(false));
+                    if (snapshotPolicy != null || releasePolicy != null) {
+                        RemoteRepository.Builder builder = new RemoteRepository.Builder(remoteRepository);
+                        Optional.ofNullable(snapshotPolicy).ifPresent(builder::setSnapshotPolicy);
+                        Optional.ofNullable(releasePolicy).ifPresent(builder::setReleasePolicy);
+                        return builder.build();
+                    } else {
+                        return remoteRepository;
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    private RepositoryPolicy forceDailyUpdatePolicy(RepositoryPolicy policy) {
+        if (policy.isEnabled() && RepositoryPolicy.UPDATE_POLICY_NEVER.equals(policy.getUpdatePolicy())) {
+            return new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, policy.getChecksumPolicy());
+        }
+        return null;
+    }
+
+    @Override
+    public void resolveArtifact(Artifact artifact, boolean usePluginRepositories) throws ArtifactResolutionException {
+        try {
+            ArtifactResult artifactResult = repositorySystem.resolveArtifact(
+                    mavenSession.getRepositorySession(),
+                    new ArtifactRequest(
+                            RepositoryUtils.toArtifact(artifact),
+                            usePluginRepositories
+                                    ? mavenSession.getCurrentProject().getRemotePluginRepositories()
+                                    : mavenSession.getCurrentProject().getRemoteProjectRepositories(),
+                            getClass().getName()));
+            artifact.setFile(artifactResult.getArtifact().getFile());
+            artifact.setVersion(artifactResult.getArtifact().getVersion());
+            artifact.setResolved(artifactResult.isResolved());
+        } catch (org.eclipse.aether.resolution.ArtifactResolutionException e) {
+            throw new ArtifactResolutionException(e.getMessage(), artifact, e);
+        }
+    }
+
+    @Override
+    public ArtifactVersions resolveArtifactVersions(
+            Artifact artifact, boolean usePluginRepositories, boolean useProjectRepositories)
+            throws VersionRetrievalException {
+        try {
+            VersionRangeRequest versionRangeRequest = new VersionRangeRequest(
+                    toArtifact(artifact).setVersion("(,)"),
+                    Stream.concat(
+                                    usePluginRepositories ? remotePluginRepositories.stream() : Stream.empty(),
+                                    useProjectRepositories ? remoteProjectRepositories.stream() : Stream.empty())
+                            .distinct()
+                            .collect(Collectors.toList()),
+                    "lookupArtifactVersions");
+
+            return new ArtifactVersions(
+                    artifact,
+                    repositorySystem
+                            .resolveVersionRange(mavenSession.getRepositorySession(), versionRangeRequest)
+                            .getVersions()
+                            .stream()
+                            .map(v -> ArtifactVersionService.getArtifactVersion(v.toString()))
+                            .collect(Collectors.toList()));
+        } catch (VersionRangeResolutionException e) {
+            throw new VersionRetrievalException(e.getMessage(), artifact, e);
+        } catch (RuntimeException e) {
+            // log the dependency should any runtime exception occur (e.x. broken comparison contract)
+            throw new VersionRetrievalException("Unable to retrieve versions for " + artifact, artifact, e);
+        }
+    }
+
+    @Override
+    public SortedMap<Dependency, ArtifactVersions> resolveDependencyVersions(
+            Collection<Dependency> dependencies, boolean usePluginRepositories, boolean useProjectRepositories)
+            throws VersionRetrievalException {
+        @SuppressWarnings("resource")
+        ExecutorService executor = Executors.newFixedThreadPool(LOOKUP_PARALLEL_THREADS);
+        try {
+            Collection<Pair<Dependency, Future<ArtifactVersions>>> futures = dependencies.stream()
+                    .map(d -> Pair.of(
+                            d,
+                            executor.submit(() -> resolveArtifactVersions(
+                                    artifactFactory.createArtifact(d), usePluginRepositories, useProjectRepositories))))
+                    .collect(Collectors.toList());
+            SortedMap<Dependency, ArtifactVersions> result = new TreeMap<>(DependencyComparator.INSTANCE);
+            for (Pair<Dependency, Future<ArtifactVersions>> entry : futures) {
+                try {
+                    result.put(entry.getKey(), entry.getValue().get());
+                } catch (InterruptedException | ExecutionException e) {
+                    if (e.getCause() instanceof VersionRetrievalException) {
+                        throw (VersionRetrievalException) e.getCause();
+                    }
+                    throw new VersionRetrievalException(
+                            "Unable to resolve metadata for dependencies " + dependencies + ": " + e.getMessage(),
+                            null,
+                            e);
+                }
+            }
+            return result;
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Override
+    public PluginUpdatesDetails resolvePluginVersions(Plugin plugin) throws VersionRetrievalException {
+        String version = plugin.getVersion() != null ? plugin.getVersion() : "LATEST";
+        Set<Dependency> pluginDependencies = Optional.ofNullable(plugin.getDependencies())
+                .map(d -> d.stream().collect(Collectors.toCollection(() ->
+                        (Set<Dependency>) new TreeSet<>(DependencyComparator.INSTANCE))))
+                .orElse(Collections.emptySet());
+        SortedMap<Dependency, ArtifactVersions> pluginDependencyDetails =
+                resolveDependencyVersions(pluginDependencies, false, true);
+        Artifact pluginArtifact =
+                artifactFactory.createMavenPluginArtifact(plugin.getGroupId(), plugin.getArtifactId(), version);
+        ArtifactVersions allVersions = resolveArtifactVersions(pluginArtifact, true, false);
+        return new PluginUpdatesDetails(allVersions, pluginDependencyDetails, true);
+    }
+
+    @Override
+    public SortedMap<Plugin, PluginUpdatesDetails> resolvePluginVersions(Collection<Plugin> plugins)
+            throws VersionRetrievalException {
+        @SuppressWarnings("resource")
+        ExecutorService executor = Executors.newFixedThreadPool(LOOKUP_PARALLEL_THREADS);
+        try {
+            SortedMap<Plugin, PluginUpdatesDetails> pluginUpdates = new TreeMap<>(PluginComparator.INSTANCE);
+            List<Future<? extends Pair<Plugin, PluginUpdatesDetails>>> futures = plugins.stream()
+                    .map(p -> executor.submit(() -> new ImmutablePair<>(p, resolvePluginVersions(p))))
+                    .collect(Collectors.toList());
+            for (Future<? extends Pair<Plugin, PluginUpdatesDetails>> details : futures) {
+                Pair<Plugin, PluginUpdatesDetails> pair = details.get();
+                pluginUpdates.put(pair.getKey(), pair.getValue());
+            }
+            return pluginUpdates;
+        } catch (ExecutionException | InterruptedException e) {
+            if (e.getCause() instanceof VersionRetrievalException) {
+                throw (VersionRetrievalException) e.getCause();
+            }
+            throw new VersionRetrievalException(
+                    "Unable to acquire metadata for plugins " + plugins + ": " + e.getMessage(), null, e);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/rule/RuleService.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/rule/RuleService.java
@@ -106,6 +106,33 @@ public class RuleService {
     /**
      * Returns a list of versions which should not be considered when looking for updates.
      *
+     * @param groupId groupId of the artifact to evaluate
+     * @param artifactId artifactId of the artifact to evaluate
+     * @return list of ignored versions (never {@code null})
+     */
+    public List<IgnoreVersion> getIgnoredVersions(String groupId, String artifactId) {
+        Rule bestFitRule = getBestFitRule(groupId, artifactId);
+        return Stream.concat(
+                        ruleSet.getIgnoreVersions().stream(),
+                        Optional.ofNullable(bestFitRule)
+                                .map(Rule::getIgnoreVersions)
+                                .map(Collection::stream)
+                                .orElse(Stream.empty()))
+                .filter(v -> {
+                    if (!IgnoreVersionHelper.isValidType(v)) {
+                        log.warn("The type attribute '" + v.getType() + "' for global ignoreVersion["
+                                + v + "] is not valid. Please use one of '" + IgnoreVersionHelper.VALID_TYPES
+                                + "'.");
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of versions which should not be considered when looking for updates.
+     *
      * @param artifact the artifact to evaluate
      * @return list of ignored versions (never {@code null})
      */

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/rule/RuleServiceUtils.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/rule/RuleServiceUtils.java
@@ -1,0 +1,51 @@
+package org.codehaus.mojo.versions.rule;
+
+import java.util.Collection;
+
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.IgnoreVersionHelper;
+import org.codehaus.mojo.versions.model.IgnoreVersion;
+
+/**
+ * Utility class for filtering artifact versions based on rules.
+ *
+ * @since 2.20.0
+ */
+public class RuleServiceUtils {
+
+    /**
+     * Filters the given {@link ArtifactVersions} by ignoring versions as specified by the {@link RuleService} for the
+     * given artifact.
+     *
+     * @param groupId          groupId of the artifact for which to filter versions
+     * @param artifactId       artifactId of the artifact for which to filter versions
+     * @param artifactVersions the {@link ArtifactVersions} to filter
+     * @param ruleService      the {@link RuleService} to retrieve ignored versions from
+     * @param log              the {@link Log} for debug output
+     * @return a new {@link ArtifactVersions} instance with ignored versions filtered out
+     * @since 2.20.0
+     */
+    public static ArtifactVersions filterByRuleService(
+            String groupId, String artifactId, ArtifactVersions artifactVersions, RuleService ruleService, Log log) {
+        Collection<IgnoreVersion> ignoredVersions;
+        ignoredVersions = ruleService.getIgnoredVersions(groupId, artifactId);
+        String artifactKey = groupId + ":" + artifactId;
+        if (!ignoredVersions.isEmpty() && log.isDebugEnabled()) {
+            log.debug("Found ignored versions: " + ignoredVersions + " for artifact " + artifactKey);
+        }
+        return new ArtifactVersions(artifactVersions)
+                .filter(version -> ignoredVersions.stream().noneMatch(i -> {
+                    if (IgnoreVersionHelper.isVersionIgnored(version, i)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Version " + version + " for artifact "
+                                    + artifactKey
+                                    + " found on ignore list: "
+                                    + i);
+                        }
+                        return true;
+                    }
+                    return false;
+                }));
+    }
+}

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReader.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReader.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -40,12 +39,13 @@ public class PropertiesVersionsFileReader {
      */
     private String propertiesCsv;
 
-    private Property[] propertiesConfig;
+    private List<Property> propertiesConfig;
 
-    private String propertyFilePath;
+    private final String propertyFilePath;
 
     /**
      * Creates an instance of the object with the given path to the property file
+     *
      * @param filePath path to the property file
      */
     public PropertiesVersionsFileReader(String filePath) {
@@ -54,28 +54,23 @@ public class PropertiesVersionsFileReader {
 
     /**
      * Reads the property file
+     *
      * @throws IOException thrown if an I/O exception occurs during the read operation
      */
     public void read() throws IOException {
         try (InputStream input = Files.newInputStream(Paths.get(propertyFilePath))) {
-
             Properties prop = new Properties();
-
             // load a properties file
             prop.load(input);
-
             prop.propertyNames();
-
             propertiesCsv = prop.keySet().stream().map(Object::toString).collect(Collectors.joining(","));
-
-            List<Property> propertiesConfigList = new ArrayList<>();
-            prop.forEach((name, version) -> {
-                Property propertyConfig = new Property((String) name);
-                propertyConfig.setVersion((String) version);
-                propertiesConfigList.add(propertyConfig);
-            });
-
-            propertiesConfig = propertiesConfigList.toArray(new Property[0]);
+            propertiesConfig = prop.entrySet().stream()
+                    .map(e -> new Property((String) e.getKey()) {
+                        {
+                            setVersion((String) e.getValue());
+                        }
+                    })
+                    .collect(Collectors.toList());
         }
     }
 
@@ -91,7 +86,7 @@ public class PropertiesVersionsFileReader {
      * Returns the array of {@link Property} objects
      * @return array of properties
      */
-    public Property[] getPropertiesConfig() {
+    public List<Property> getPropertiesConfig() {
         return propertiesConfig;
     }
 }

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -48,6 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
@@ -303,5 +305,43 @@ class ArtifactVersionsTest {
                 .collect(Collectors.toList());
         assertThat(allUpdates, hasItem("4"));
         assertThat(allUpdates, allOf(not(hasItem("1")), not(hasItem("2")), not(hasItem("3"))));
+    }
+
+    @Test
+    void testPredicate() {
+        ArtifactVersions original = new ArtifactVersions(
+                new DefaultArtifact("default-group", "dummy-api", "1.1.2-SNAPSHOT", "foo", "bar", "jar", null),
+                Arrays.asList(versions(
+                        "1.0.1",
+                        "1.0",
+                        "1.1.0-2",
+                        "1.1.1",
+                        "1.1.1-2",
+                        "1.1.2",
+                        "1.1.2-SNAPSHOT",
+                        "1.1.3",
+                        "1.1",
+                        "1.1-SNAPSHOT",
+                        "1.2.1",
+                        "1.2.2",
+                        "1.2",
+                        "1.3",
+                        "1.9.1-SNAPSHOT",
+                        "2.0",
+                        "2.1.1-SNAPSHOT",
+                        "2.1",
+                        "3.0",
+                        "3.1.1-SNAPSHOT",
+                        "3.1.5-SNAPSHOT",
+                        "3.4.0-SNAPSHOT")));
+        ArtifactVersions onlySnapshots = new ArtifactVersions(original).filter(ArtifactUtils::isSnapshot);
+        assertThat(onlySnapshots.getVersions(false), emptyArray());
+        assertThat(onlySnapshots.getVersions(true), arrayWithSize(7));
+        assertThat(onlySnapshots.getCurrentVersion(), is(original.getCurrentVersion()));
+
+        ArtifactVersions noSnapshots = new ArtifactVersions(original).filter(v -> !ArtifactUtils.isSnapshot(v));
+        assertThat(noSnapshots.getVersions(false), arrayWithSize(15));
+        assertThat(noSnapshots.getVersions(true), arrayWithSize(15));
+        assertThat(noSnapshots.getCurrentVersion(), nullValue());
     }
 }

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/DefaultVersionsHelperTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -179,7 +180,7 @@ class DefaultVersionsHelperTest {
         VersionsHelper helper = createHelper();
         MavenProject project = null;
 
-        Property[] propertyDefinitions = new Property[] {new Property("bar.version")};
+        List<Property> propertyDefinitions = Collections.singletonList(new Property("bar.version"));
         // should not throw an IllegalStateException
         Map<Property, PropertyVersions> result =
                 helper.getVersionPropertiesMap(VersionsHelper.VersionPropertiesMapRequest.builder()

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReaderTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/utils/PropertiesVersionsFileReaderTest.java
@@ -43,7 +43,7 @@ class PropertiesVersionsFileReaderTest {
         int numberOfPropertiesConfig = 3;
         assertTrue(equalsCvsUnordered(
                 "booking-api.version,booking-lib.version,be-air-impl.version", reader.getProperties()));
-        assertEquals(numberOfPropertiesConfig, reader.getPropertiesConfig().length);
+        assertEquals(numberOfPropertiesConfig, reader.getPropertiesConfig().size());
     }
 
     private boolean equalsCvsUnordered(String csvExpected, String csvActual) {

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/invoker.properties
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:display-dependency-updates
+invoker.mavenOpts = -Dversions.outputFile=./output.txt -DoutputEncoding=UTF-8

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/pom.xml
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>it-display-dependency-updates-issue-1295-version-ranges</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>[1.1,4.0)</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/verify.groovy
+++ b/versions-maven-plugin/src/it/it-display-dependency-updates-issue-1295-version-ranges/verify.groovy
@@ -1,0 +1,2 @@
+def output = new File(basedir, "output.txt").text
+assert output =~ /No dependencies in Dependencies have newer versions./

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReport.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractPropertyUpdatesReport.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -33,7 +34,7 @@ import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.wagon.Wagon;
 import org.codehaus.mojo.versions.api.Property;
 import org.codehaus.mojo.versions.api.PropertyVersions;
-import org.codehaus.mojo.versions.api.VersionsHelper.VersionPropertiesMapRequest;
+import org.codehaus.mojo.versions.api.VersionsHelper;
 import org.codehaus.mojo.versions.reporting.ReportRendererFactory;
 import org.codehaus.mojo.versions.reporting.model.PropertyUpdatesModel;
 import org.codehaus.mojo.versions.utils.ArtifactFactory;
@@ -57,7 +58,7 @@ public abstract class AbstractPropertyUpdatesReport extends AbstractVersionsRepo
      * @since 1.0-beta-1
      */
     @Parameter
-    private Property[] properties;
+    private List<Property> properties;
 
     /**
      * A comma separated list of properties to include in the report.
@@ -199,15 +200,15 @@ public abstract class AbstractPropertyUpdatesReport extends AbstractVersionsRepo
     }
 
     /**
-     * Creates a new instance of the {@link VersionPropertiesMapRequest} based on the provided {@link MavenProject}.
+     * Creates a new instance of the {@link VersionsHelper.VersionPropertiesMapRequest} based on the provided {@link MavenProject}.
      * The created instance is built taking into consideration the provided project as well as parameters of the Mojo
      * such as {@link #properties}, {@link #includeProperties}, {@link #excludeProperties}, {@link #includeParent},
      * {@link #autoLinkItems}.
      * @param project {@link MavenProject} instance for which the request is to be generated
-     * @return an initialised {@link VersionPropertiesMapRequest} instance
+     * @return an initialised {@link VersionsHelper.VersionPropertiesMapRequest} instance
      */
-    protected VersionPropertiesMapRequest getRequest(MavenProject project) {
-        return VersionPropertiesMapRequest.builder()
+    protected VersionsHelper.VersionPropertiesMapRequest getRequest(MavenProject project) {
+        return VersionsHelper.VersionPropertiesMapRequest.builder()
                 .withMavenProject(project)
                 .withPropertyDefinitions(this.properties)
                 .withIncludeProperties(this.includeProperties)

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsUpdaterMojo.java
@@ -98,7 +98,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
      * @since 1.0-alpha-3
      */
     @Parameter(property = "maven.version.rules.serverId", defaultValue = "serverId")
-    private String serverId;
+    protected String serverId;
 
     /**
      * URI of a ruleSet file containing the rules that control how to compare
@@ -108,7 +108,7 @@ public abstract class AbstractVersionsUpdaterMojo extends AbstractMojo {
      * @since 1.0-alpha-3
      */
     @Parameter(property = "maven.version.rules")
-    private String rulesUri;
+    protected String rulesUri;
 
     /**
      * Controls whether a backup pom should be created.

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojo.java
@@ -75,7 +75,7 @@ public class DisplayPropertyUpdatesMojo extends AbstractVersionsDisplayMojo {
      * @since 1.0-alpha-3
      */
     @Parameter
-    private Property[] properties;
+    private List<Property> properties;
 
     /**
      * A comma separated list of properties to update.

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -24,7 +24,9 @@ import javax.xml.stream.XMLStreamException;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -137,7 +139,7 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
      */
     protected void update(MutableXMLStreamReader pom)
             throws MojoExecutionException, MojoFailureException, XMLStreamException {
-        Property[] propertiesConfig;
+        List<Property> propertiesConfig;
         String properties;
         if (!isEmpty(propertiesVersionsFile)) {
             logWrongConfigWarning();
@@ -161,7 +163,7 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
                         propertyConfig.setVersion(newVersion);
                         return propertyConfig;
                     })
-                    .toArray(Property[]::new);
+                    .collect(Collectors.toList());
             properties = property;
         } else {
             throw new MojoExecutionException("Please provide either 'property' or 'propertiesVersionsFile' parameter.");
@@ -169,7 +171,7 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
         update(pom, propertiesConfig, properties);
     }
 
-    private void update(MutableXMLStreamReader pom, Property[] propertiesConfig, String properties)
+    private void update(MutableXMLStreamReader pom, List<Property> propertiesConfig, String properties)
             throws MojoExecutionException, XMLStreamException {
         Map<Property, PropertyVersions> propertyVersions = this.getHelper()
                 .getVersionPropertiesMap(VersionsHelper.VersionPropertiesMapRequest.builder()

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertiesMojo.java
@@ -22,6 +22,7 @@ package org.codehaus.mojo.versions;
 import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -50,7 +51,7 @@ public class UpdatePropertiesMojo extends UpdatePropertiesMojoBase {
      * @since 1.0-alpha-3
      */
     @Parameter
-    private Property[] properties;
+    private List<Property> properties;
 
     /**
      * A comma separated list of properties to update.

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UpdatePropertyMojo.java
@@ -22,6 +22,7 @@ package org.codehaus.mojo.versions;
 import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -98,10 +99,10 @@ public class UpdatePropertyMojo extends UpdatePropertiesMojoBase {
     /**
      * Creates a new instance
      *
-     * @param artifactFactory   the artifact factory
-     * @param repositorySystem  the repository system
-     * @param wagonMap          the wagon map
-     * @param changeRecorders   the change recorders
+     * @param artifactFactory  the artifact factory
+     * @param repositorySystem the repository system
+     * @param wagonMap         the wagon map
+     * @param changeRecorders  the change recorders
      * @throws MojoExecutionException if any
      */
     @Inject
@@ -144,13 +145,11 @@ public class UpdatePropertyMojo extends UpdatePropertiesMojoBase {
                 getHelper()
                         .getVersionPropertiesMap(VersionsHelper.VersionPropertiesMapRequest.builder()
                                 .withMavenProject(getProject())
-                                .withPropertyDefinitions(new Property[] {
-                                    new Property(property) {
-                                        {
-                                            setVersion(newVersion);
-                                        }
+                                .withPropertyDefinitions(Collections.singletonList(new Property(property) {
+                                    {
+                                        setVersion(newVersion);
                                     }
-                                })
+                                }))
                                 .withIncludeProperties(property)
                                 .withAutoLinkItems(autoLinkItems)
                                 .withIncludeParent(includeParent)


### PR DESCRIPTION
Over time, VersionsHelper has evolved into a behemoth with multiple, diverging responsibilities—a "helper" class performing various tasks for the plugin's mojos. Its broad scope has led to a tightly coupled and entangled architecture that is difficult to navigate and maintain. Several convenience methods, such as lookupDependenciesUpdates, perform similar but slightly different tasks, adding to the complexity.

One consequence of this design is inconsistency across mojos that operate in similar domains. For example, displayDependencyUpdates and useLatestVersions rely on different methods within VersionsHelper, each executing subtly different retrieval logic. In the case of the display mojo, filtering is applied twice: first within the helper (e.g., excluding snapshots), and then again in the mojo itself.

The ultimate goal is to clean up this architecture and potentially introduce a shared backend that can be used by plugins responsible for updating and displaying dependencies. Achieving this requires a simpler, more modular design.

This PR introduces a thin wrapper around Resolver, focused solely on retrieving available versions—essentially translating Resolver functionality into Maven terms. Once versions are retrieved, filtering can be handled cleanly via ArtifactVersions.

To demonstrate this approach, DisplayDependencyUpdates and DisplayExtensionUpdates have been refactored to use the new API.

Additionally, VersionsHelper has been extended to support the new API, allowing underlying components such as RuleService to work with both VersionsHelper and the new ResolverAdapter.

A minor improvement: PropertyBuilder now uses a collection for Properties, aligning the API more closely with future enhancements.