### PR TITLE
Fixed #1313: Do not show existing version as update

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -120,6 +120,7 @@ public abstract class AbstractVersionDetails implements VersionDetails {
         return Optional.ofNullable(getCurrentVersionRange())
                 .map(VersionRange::getRestrictions)
                 .flatMap(r -> r.stream()
+                        .filter(rr -> rr.getLowerBound() != null || rr.getUpperBound() != null)
                         .filter(rr -> rr.containsVersion(selectedVersion))
                         .findAny());
     }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/internal/DependencyUpdatesLoggingHelper.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/internal/DependencyUpdatesLoggingHelper.java
@@ -142,6 +142,7 @@ public class DependencyUpdatesLoggingHelper {
                 latestVersion = Optional.of(newVersionRestriction)
                         .map(restriction -> versions.getNewestVersion(restriction, allowSnapshots));
             }
+
             String right =
                     " " + latestVersion.map(v -> currentVersion + " -> " + v).orElse(currentVersion);
             List<String> t = latestVersion.isPresent() ? withUpdates : usingCurrent;

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayParentUpdatesMojoTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -55,7 +56,9 @@ import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySys
 import static org.codehaus.mojo.versions.utils.MockUtils.mockArtifactHandlerManager;
 import static org.codehaus.mojo.versions.utils.MockUtils.mockMavenSession;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -410,5 +413,20 @@ public class DisplayParentUpdatesMojoTest {
             VersionRetrievalException vre = (VersionRetrievalException) e.getCause();
             assertThat(vre.getArtifact().map(Artifact::getArtifactId).orElse(""), equalTo("problem-causing-artifact"));
         }
+    }
+
+    @Test
+    public void testLatestVersion() throws Exception {
+        mojo.getProject().setParent(new MavenProject() {
+            {
+                setGroupId("default-group");
+                setArtifactId("parent-artifact");
+                setVersion("1.0.0");
+            }
+        });
+        mojo.allowSnapshots = false;
+        mojo.execute();
+        List<String> output = Files.readAllLines(tempFile);
+        assertThat(output, hasItem(containsString("The parent project is the latest version")));
     }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPluginUpdatesMojoTest.java
@@ -183,4 +183,18 @@ public class DisplayPluginUpdatesMojoTest extends AbstractMojoTestCase {
             assertThat(vre.getArtifact().map(Artifact::getArtifactId).orElse(""), equalTo("problem-causing-artifact"));
         }
     }
+
+    @Test
+    public void testLatestVersion() throws Exception {
+        Files.copy(
+                Paths.get("src/test/resources/org/codehaus/mojo/display-plugin-updates/updates-only.xml"),
+                tempDir.resolve("pom.xml"));
+
+        DisplayPluginUpdatesMojo mojo = createMojo();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(outputPath);
+        assertThat(
+                output, hasItem(containsString("All plugins with a version specified are using the latest versions.")));
+    }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/DisplayPropertyUpdatesMojoTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -36,6 +37,7 @@ import static org.codehaus.mojo.versions.utils.MockUtils.mockAetherRepositorySys
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
@@ -155,5 +157,23 @@ public class DisplayPropertyUpdatesMojoTest extends AbstractMojoTestCase {
             VersionRetrievalException vre = (VersionRetrievalException) e.getCause();
             assertThat(vre.getArtifact().map(Artifact::getArtifactId).orElse(""), equalTo("problem-causing-artifact"));
         }
+    }
+
+    @Test
+    public void testLatestVersion() throws Exception {
+        TestUtils.copyDir(
+                Paths.get("src/test/resources/org/codehaus/mojo/display-property-updates/updates-only"), tempDir);
+        DisplayPropertyUpdatesMojo mojo = (DisplayPropertyUpdatesMojo)
+                mojoRule.lookupConfiguredMojo(tempDir.toFile(), "display-property-updates");
+        mojo.outputEncoding = UTF_8;
+        mojo.outputFile = tempFile.toFile();
+        mojo.setPluginContext(new HashMap<>());
+        mojo.repositorySystem = mockAetherRepositorySystem();
+        mojo.execute();
+
+        List<String> output = Files.readAllLines(tempFile);
+        assertThat(
+                output,
+                hasItem(containsString("All version properties are referencing the newest version available.")));
     }
 }

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/updates-only.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-plugin-updates/updates-only.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test-group</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>DEVELOP-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>default-group</groupId>
+        <artifactId>default-plugin</artifactId>
+        <version>1.0.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-property-updates/updates-only/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-property-updates/updates-only/pom.xml
@@ -1,0 +1,19 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default-group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <ver>1.0.0</ver>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>default-group</groupId>
+            <artifactId>artifactC</artifactId>
+            <version>${ver}</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Fixes a regression: current version should not be displayed as an update.