### PR TITLE
Fixed #1317: Regression coming from ArtifactVersions::filter when currentVersion is null and ignoredVersions is not null

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/ArtifactVersions.java
@@ -88,7 +88,7 @@ public class ArtifactVersions extends AbstractVersionDetails implements Comparab
         ArtifactVersions result = new ArtifactVersions(
                 artifact,
                 versions.stream().filter(v -> versionFilter.test(v.toString())).collect(Collectors.toList()));
-        if (!versionFilter.test(result.artifact.getVersion())) {
+        if (result.artifact.getVersion() != null && !versionFilter.test(result.artifact.getVersion())) {
             result.setCurrentVersion((ArtifactVersion) null);
         }
         return result;

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/IgnoreVersionHelper.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/IgnoreVersionHelper.java
@@ -15,6 +15,8 @@ package org.codehaus.mojo.versions.api;
  * limitations under the License.
  */
 
+import javax.annotation.Nonnull;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -92,13 +94,17 @@ public class IgnoreVersionHelper {
     }
 
     /**
-     * Check if the provided version is ignored by the provided {@link IgnoreVersion} instance
+     * <p>Check if the provided version is ignored by the provided {@link IgnoreVersion} instance.</p>
+     * <p>In the rare case that the {@code v} should be be {@code null}, the function returns {@code true}.</p>
      *
      * @param v version string to be checked
      * @param ignoreVersion {@link IgnoreVersion} instance providing the filter
-     * @return {@code true} if the provided version is ignored
+     * @return {@code true} if the provided version is ignored or if it is equal to {@code null}.
      */
     public static boolean isVersionIgnored(String v, IgnoreVersion ignoreVersion) {
+        if (v == null) {
+            return true;
+        }
         return IgnoreVersionType.forType(ignoreVersion.getType())
                 .map(t -> t.getPredicate().apply(v, ignoreVersion))
                 .orElseThrow(() -> new IllegalArgumentException("Invalid version type: " + ignoreVersion.getType()));
@@ -111,7 +117,7 @@ public class IgnoreVersionHelper {
      * @param ignoreVersion {@link IgnoreVersion} instance providing the filter
      * @return {@code true} if the provided version is ignored
      */
-    public static boolean isVersionIgnored(Version v, IgnoreVersion ignoreVersion) {
+    public static boolean isVersionIgnored(@Nonnull Version v, IgnoreVersion ignoreVersion) {
         return isVersionIgnored(v.toString(), ignoreVersion);
     }
 
@@ -119,11 +125,11 @@ public class IgnoreVersionHelper {
         return ignoreVersion.getVersion().equals(v);
     }
 
-    private static boolean isVersionIgnoredRegex(String v, IgnoreVersion ignoreVersion) {
+    private static boolean isVersionIgnoredRegex(@Nonnull String v, IgnoreVersion ignoreVersion) {
         return Pattern.compile(ignoreVersion.getVersion()).matcher(v).matches();
     }
 
-    private static boolean isVersionIgnoredRange(String v, IgnoreVersion ignoreVersion) {
+    private static boolean isVersionIgnoredRange(@Nonnull String v, IgnoreVersion ignoreVersion) {
         try {
             ArtifactVersion aVersion = ArtifactVersionService.getArtifactVersion(v);
             VersionRange versionRange = VersionRange.createFromVersionSpec(ignoreVersion.getVersion());

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/IgnoreVersionHelperTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/IgnoreVersionHelperTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 class IgnoreVersionHelperTest {
@@ -62,6 +63,15 @@ class IgnoreVersionHelperTest {
 
         assertEquals(
                 expected, IgnoreVersionHelper.isVersionIgnored(VERSION_SCHEME.parseVersion(version), ignoreVersion));
+    }
+
+    /*
+     * Additional safety measure: prevent a NPE coming from Matcher if the current version happens to be null.
+     */
+    @Test
+    public void testNullIgnoreVersion() {
+        IgnoreVersion ignoreVersion = aIgnoreVersion("Alpha", IgnoreVersion.TYPE_REGEX);
+        assertTrue(IgnoreVersionHelper.isVersionIgnored((String) null, ignoreVersion));
     }
 
     public static Stream<Arguments> ignoredTypeRange() {

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/ranges/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/display-dependency-updates/ranges/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>default-group</groupId>
+  <artifactId>default-artifact</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>(,2.0.0)</version>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
This is caused by a refactoring job of RuleService using the new ArtifactVersions::filter, which causes IgnoreVersionHelper to trigger an NPE. 

Fixed both the root cause (testing against a non-existing version) as well as the susceptibility of the IgnoreVersionHelper to trigger an NPE if the version is null. 