### PR TITLE
UseDepVersionMoto should process all projects on the project list

### DIFF
--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/AbstractVersionsDependencyUpdaterMojo.java
@@ -486,6 +486,7 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
      * Attempts to update the dependency {@code dep} to the given {@code newVersion}. The dependency can either
      * be the parent project or any given dependency.
      *
+     * @param project {@link MavenProject} being updated
      * @param pom {@link MutableXMLStreamReader} instance to update the POM XML document
      * @param dep dependency to be updated (can also be a dependency made from the parent)
      * @param newVersion new version to update the dependency to
@@ -495,11 +496,15 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
      * @throws MojoExecutionException thrown if the dependency cannot be converted to an artifact
      */
     protected boolean updateDependencyVersion(
-            MutableXMLStreamReader pom, Dependency dep, String newVersion, DependencyChangeRecord.ChangeKind changeKind)
+            MavenProject project,
+            MutableXMLStreamReader pom,
+            Dependency dep,
+            String newVersion,
+            DependencyChangeRecord.ChangeKind changeKind)
             throws XMLStreamException, MojoExecutionException {
         boolean updated = false;
         if (getProcessParent()
-                && getProject().getParent() != null
+                && project.getParent() != null
                 && (DependencyComparator.INSTANCE.compare(
                                         dep,
                                         DependencyBuilder.newBuilder()
@@ -554,7 +559,8 @@ public abstract class AbstractVersionsDependencyUpdaterMojo extends AbstractVers
                 getProject().getModel(),
                 getLog())) {
             if (getLog().isInfoEnabled()) {
-                getLog().info("Updated " + toString(dep) + " to version " + newVersion);
+                getLog().info("Updated " + toString(dep) + " to version " + newVersion + " in " + project.getGroupId()
+                        + ":" + project.getArtifactId() + ":" + project.getVersion());
             }
             getChangeRecorder()
                     .recordChange(DefaultDependencyChangeRecord.builder()

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/CompareDependenciesMojo.java
@@ -238,6 +238,7 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
         List<String> propertyDiffs = new ArrayList<>();
         if (getProject().getDependencyManagement() != null && getProcessDependencyManagement()) {
             totalDiffs.addAll(compareVersions(
+                    getProject(),
                     pom,
                     getProject().getDependencyManagement().getDependencies(),
                     remoteDepsMap,
@@ -245,7 +246,11 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
         }
         if (getProject().getDependencies() != null && getProcessDependencies()) {
             totalDiffs.addAll(compareVersions(
-                    pom, getProject().getDependencies(), remoteDepsMap, DependencyChangeRecord.ChangeKind.DEPENDENCY));
+                    getProject(),
+                    pom,
+                    getProject().getDependencies(),
+                    remoteDepsMap,
+                    DependencyChangeRecord.ChangeKind.DEPENDENCY));
         }
         if (updatePropertyVersions) {
             Map<Property, PropertyVersions> versionProperties = this.getHelper()
@@ -268,6 +273,7 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
             }
             remoteDepsMap.putIfAbsent(parent.getManagementKey(), parent);
             totalDiffs.addAll(compareVersions(
+                    getProject(),
                     pom,
                     singletonList(getParentDependency()),
                     remoteDepsMap,
@@ -338,6 +344,7 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
      * @throws MojoExecutionException
      */
     private List<String> compareVersions(
+            MavenProject project,
             MutableXMLStreamReader pom,
             List<Dependency> dependencies,
             Map<String, Dependency> remoteDependencies,
@@ -357,7 +364,7 @@ public class CompareDependenciesMojo extends AbstractVersionsDependencyUpdaterMo
                     StringBuilder buf = writeDependencyDiffMessage(dep, remoteVersion);
                     updates.add(buf.toString());
                     if (!reportMode) {
-                        updateDependencyVersion(pom, dep, remoteVersion, changeKind);
+                        updateDependencyVersion(project, pom, dep, remoteVersion, changeKind);
                     }
                 }
             }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/ForceReleasesMojo.java
@@ -183,7 +183,7 @@ public class ForceReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
                 getLog().debug("Looking for a release of " + toString(dep));
                 ArtifactVersions versions = getHelper().lookupArtifactVersions(artifact, false);
                 if (versions.containsVersion(releaseVersion)) {
-                    updateDependencyVersion(pom, dep, releaseVersion, changeKind);
+                    updateDependencyVersion(getProject(), pom, dep, releaseVersion, changeKind);
                 } else {
                     ArtifactVersion newestRelease = versions.getNewestVersion((VersionRange) null, null, false, true);
                     if (newestRelease == null) {
@@ -193,7 +193,7 @@ public class ForceReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
                                     "No matching release of " + toString(dep) + " found for update.");
                         }
                     } else {
-                        updateDependencyVersion(pom, dep, newestRelease.toString(), changeKind);
+                        updateDependencyVersion(getProject(), pom, dep, newestRelease.toString(), changeKind);
                     }
                 }
             }

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojoBase.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseLatestVersionsMojoBase.java
@@ -248,7 +248,8 @@ public abstract class UseLatestVersionsMojoBase extends AbstractVersionsDependen
             CompletableFuture.allOf(versionChangeFutures.toArray(new CompletableFuture[0]))
                     .join();
             for (DependencyVersionChange change : versionChanges) {
-                updateDependencyVersion(pom, change.getDependency(), change.getNewVersion(), change.getChangeKind());
+                updateDependencyVersion(
+                        getProject(), pom, change.getDependency(), change.getNewVersion(), change.getChangeKind());
             }
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/UseReleasesMojo.java
@@ -206,7 +206,7 @@ public class UseReleasesMojo extends AbstractVersionsDependencyUpdaterMojo {
                 Optional<String> targetVersion =
                         findReleaseVersion(releaseVersion, getHelper().lookupArtifactVersions(artifact, false));
                 if (targetVersion.isPresent()) {
-                    updateDependencyVersion(pom, dep, targetVersion.get(), changeKind);
+                    updateDependencyVersion(getProject(), pom, dep, targetVersion.get(), changeKind);
                 } else {
                     getLog().info("No matching release of " + toString(dep) + " to update.");
                     if (failIfNotReplaced) {

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/mod1/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/mod1/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>default-group</groupId>
+  <artifactId>mod1</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>default-group</groupId>
+      <artifactId>dependencyA</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/mod2/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/mod2/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>default-group</groupId>
+  <artifactId>mod2</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>default-group</groupId>
+      <artifactId>dependencyA</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/use-dep-version/module-list/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>default-group</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>mod1</module>
+    <module>mod2</module>
+  </modules>
+
+</project>


### PR DESCRIPTION
First on the list of similar PRs to come, but only this one has been reported as a regression: there are other mojos which have aggregator = true but only process the first project: they typically only act upon getProject() or session.getCurrentProject().

Here only fixing the one in UseDepVersion since it's a regression, and for simplicity's sake.

Edit: modified so that we also say where the change is being made; without that, the plugin would simply state that it's updating a dependency without saying in which module.