### PR TITLE
Add artifact classifier to ChangeRocorderXML

### DIFF
--- a/versions-api/src/main/java/org/codehaus/mojo/versions/api/change/DependencyVersionChange.java
+++ b/versions-api/src/main/java/org/codehaus/mojo/versions/api/change/DependencyVersionChange.java
@@ -39,6 +39,13 @@ public interface DependencyVersionChange extends VersionChange {
     String getArtifactId();
 
     /**
+     * Returns the classifier of the dependency
+     * @return classifier of the dependency
+     * @since 2.20.2
+     */
+    String getClassifier();
+
+    /**
      * Returns the old version of the dependency
      * @return old version the dependency
      * @since 2.14.0

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/change/DefaultDependencyVersionChange.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/change/DefaultDependencyVersionChange.java
@@ -30,6 +30,8 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
 
     private final String artifactId;
 
+    private final String classifier;
+
     private final String oldVersion;
 
     private final String newVersion;
@@ -42,8 +44,14 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
      * @param newVersion new version
      */
     public DefaultDependencyVersionChange(String groupId, String artifactId, String oldVersion, String newVersion) {
+        this(groupId, artifactId, null, oldVersion, newVersion);
+    }
+
+    public DefaultDependencyVersionChange(
+            String groupId, String artifactId, String classifier, String oldVersion, String newVersion) {
         this.groupId = groupId;
         this.artifactId = artifactId;
+        this.classifier = classifier;
         this.oldVersion = oldVersion;
         this.newVersion = newVersion;
     }
@@ -62,6 +70,14 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
      */
     public String getArtifactId() {
         return artifactId;
+    }
+
+    /**
+     * Returns the classifier of the dependency
+     * @return classifier of the dependency
+     */
+    public String getClassifier() {
+        return classifier;
     }
 
     /**
@@ -94,6 +110,11 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
         if (!Objects.equals(artifactId, versionChange.artifactId)) {
             return false;
         }
+
+        if (!Objects.equals(classifier, versionChange.classifier)) {
+            return false;
+        }
+
         if (!Objects.equals(groupId, versionChange.groupId)) {
             return false;
         }
@@ -107,6 +128,7 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
     public int hashCode() {
         int result = groupId != null ? groupId.hashCode() : 0;
         result = 31 * result + (artifactId != null ? artifactId.hashCode() : 0);
+        result = 31 * result + (classifier != null ? classifier.hashCode() : 0);
         result = 31 * result + (oldVersion != null ? oldVersion.hashCode() : 0);
         result = 31 * result + (newVersion != null ? newVersion.hashCode() : 0);
         return result;
@@ -114,7 +136,7 @@ public final class DefaultDependencyVersionChange implements DependencyVersionCh
 
     @Override
     public String toString() {
-        return "DefaultDependencyVersionChange(" + groupId + ':' + artifactId + ":" + oldVersion + "-->" + newVersion
-                + ')';
+        return "DefaultDependencyVersionChange(" + groupId + ':' + artifactId + ':' + classifier + ":" + oldVersion
+                + "-->" + newVersion + ')';
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderXML.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/recording/ChangeRecorderXML.java
@@ -82,6 +82,9 @@ public class ChangeRecorderXML implements ChangeRecorder {
         DependencyVersionChange change = (DependencyVersionChange) changeRecord.getVersionChange();
         update.setAttribute("groupId", change.getGroupId());
         update.setAttribute("artifactId", change.getArtifactId());
+        if (change.getClassifier() != null) {
+            update.setAttribute("classifier", change.getClassifier());
+        }
         update.setAttribute("oldVersion", change.getOldVersion());
         update.setAttribute("newVersion", change.getNewVersion());
 

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/recording/DefaultDependencyChangeRecord.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/recording/DefaultDependencyChangeRecord.java
@@ -63,6 +63,7 @@ public class DefaultDependencyChangeRecord implements DependencyChangeRecord {
         private ChangeKind kind;
         private String groupId;
         private String artifactId;
+        private String classifier;
         private String oldVersion;
         private String newVersion;
 
@@ -99,6 +100,16 @@ public class DefaultDependencyChangeRecord implements DependencyChangeRecord {
         }
 
         /**
+         * Supplies the classifier
+         * @param classifier requested classifier
+         * @return builder instance
+         */
+        public Builder withClassifier(String classifier) {
+            this.classifier = classifier;
+            return this;
+        }
+
+        /**
          * Supplies the version from before the change
          * @param oldVersion version from before the change
          * @return builder instance
@@ -126,6 +137,7 @@ public class DefaultDependencyChangeRecord implements DependencyChangeRecord {
         public Builder withDependency(Dependency dependency) {
             groupId = dependency.getGroupId();
             artifactId = dependency.getArtifactId();
+            classifier = dependency.getClassifier();
             oldVersion = dependency.getVersion();
             return this;
         }
@@ -138,6 +150,7 @@ public class DefaultDependencyChangeRecord implements DependencyChangeRecord {
         public Builder withArtifact(Artifact artifact) {
             groupId = artifact.getGroupId();
             artifactId = artifact.getArtifactId();
+            classifier = artifact.getClassifier();
             oldVersion = artifact.getVersion();
             return this;
         }
@@ -148,7 +161,7 @@ public class DefaultDependencyChangeRecord implements DependencyChangeRecord {
          */
         public DependencyChangeRecord build() {
             return new DefaultDependencyChangeRecord(
-                    kind, new DefaultDependencyVersionChange(groupId, artifactId, oldVersion, newVersion));
+                    kind, new DefaultDependencyVersionChange(groupId, artifactId, classifier, oldVersion, newVersion));
         }
     }
 }

--- a/versions-maven-plugin/src/it/it-changerecord-update-properties-002/invoker.properties
+++ b/versions-maven-plugin/src/it/it-changerecord-update-properties-002/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-DchangeRecorderFormat=xml ${project.groupId}:${project.artifactId}:${project.version}:update-properties

--- a/versions-maven-plugin/src/it/it-changerecord-update-properties-002/pom.xml
+++ b/versions-maven-plugin/src/it/it-changerecord-update-properties-002/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>localhost</groupId>
+	<artifactId>it-changerecord-update-properties-002</artifactId>
+	<version>1.0</version>
+	<packaging>pom</packaging>
+	<name>update-properties with classifier</name>
+
+	<properties>
+		<dummy-impl.version>1.0</dummy-impl.version>
+		<dummy-impl.classifier1.version>1.0</dummy-impl.classifier1.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>localhost</groupId>
+			<artifactId>dummy-impl</artifactId>
+			<version>${dummy-impl.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>localhost</groupId>
+			<artifactId>dummy-impl</artifactId>
+			<classifier>classifier1</classifier>
+			<version>${dummy-impl.classifier1.version}</version>
+		</dependency>
+
+	</dependencies>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>2.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.3</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>2.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>2.0</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/versions-maven-plugin/src/it/it-changerecord-update-properties-002/verify.groovy
+++ b/versions-maven-plugin/src/it/it-changerecord-update-properties-002/verify.groovy
@@ -1,0 +1,15 @@
+import groovy.xml.XmlSlurper
+
+def changes = new XmlSlurper().parse( new File( basedir, 'target/versions-changes.xml' ) )
+assert (changes.dependencyUpdate.findAll { node -> node.@kind == 'property-update'
+        && node.@groupId == 'localhost'
+        && node.@artifactId == 'dummy-impl'
+        && node.@oldVersion == '1.0'
+        && node.@newVersion == '2.2' }.size() == 2)
+
+assert (changes.dependencyUpdate.findAll { node -> node.@kind == 'property-update'
+        && node.@groupId == 'localhost'
+        && node.@artifactId == 'dummy-impl'
+        && node.@classifier == 'classifier1'
+        && node.@oldVersion == '1.0'
+        && node.@newVersion == '2.2' }.size() == 1)

--- a/versions-maven-plugin/src/main/resources/org/codehaus/mojo/versions/recording/schema-2.0.xsd
+++ b/versions-maven-plugin/src/main/resources/org/codehaus/mojo/versions/recording/schema-2.0.xsd
@@ -28,6 +28,7 @@
                 <attribute name="kind" type="string" use="required"/>
                 <attribute name="groupId" type="string" use="required"/>
                 <attribute name="artifactId" type="string" use="required"/>
+                <attribute name="classifier" type="string"/>
                 <attribute name="oldVersion" type="string" use="required"/>
                 <attribute name="newVersion" type="string" use="required"/>
             </extension>

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTest.java
@@ -99,7 +99,7 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact", "1.1.1-SNAPSHOT", "1.1.0")));
+                        "default-group", "dependency-artifact", "default", "1.1.1-SNAPSHOT", "1.1.0")));
     }
 
     @Test
@@ -128,8 +128,7 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact",
-                        "1.1.0-SNAPSHOT", "1.1.0")));
+                        "default-group", "dependency-artifact", "default", "1.1.0-SNAPSHOT", "1.1.0")));
     }
 
     @Test
@@ -147,8 +146,7 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact",
-                        "1.1.1-SNAPSHOT", "1.1.0")));
+                        "default-group", "dependency-artifact", "default", "1.1.1-SNAPSHOT", "1.1.0")));
     }
 
     @Test
@@ -166,7 +164,7 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact", "1.1.1-SNAPSHOT", "1.1.0")));
+                        "default-group", "dependency-artifact", "default", "1.1.1-SNAPSHOT", "1.1.0")));
     }
 
     @Test
@@ -235,7 +233,7 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact", "1.1.1-SNAPSHOT", "1.1.0")));
+                        "default-group", "dependency-artifact", "default", "1.1.1-SNAPSHOT", "1.1.0")));
     }
 
     @Test
@@ -261,7 +259,8 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         // With allowPreReleases=false (default), beta is excluded and 1.1.0 is selected
         assertThat(
                 changeRecorder.getChanges(),
-                hasItem(new DefaultDependencyVersionChange("default-group", "pre-release-artifact", "1.0.0", "1.1.0")));
+                hasItem(new DefaultDependencyVersionChange(
+                        "default-group", "pre-release-artifact", "default", "1.0.0", "1.1.0")));
     }
 
     @Test
@@ -288,6 +287,6 @@ public class UseLatestVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "pre-release-artifact", "1.0.0", "1.2.0-beta1")));
+                        "default-group", "pre-release-artifact", "default", "1.0.0", "1.2.0-beta1")));
     }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTestBase.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsMojoTestBase.java
@@ -154,7 +154,7 @@ public abstract class UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "other-artifact", "1.0", expectedNewVersion)));
+                        "default-group", "other-artifact", "default", "1.0", expectedNewVersion)));
     }
 
     @Test

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsRaceConditionTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseLatestVersionsRaceConditionTest.java
@@ -169,10 +169,8 @@ public class UseLatestVersionsRaceConditionTest {
                 changeRecorder.getChanges(),
                 allOf(
                         hasItem(new DefaultDependencyVersionChange(
-                                "default-group", "artifactA",
-                                "1.0.0", "2.0.0")),
+                                "default-group", "artifactA", "default", "1.0.0", "2.0.0")),
                         hasItem(new DefaultDependencyVersionChange(
-                                "default-group", "artifactB",
-                                "1.0.0", "1.1.0"))));
+                                "default-group", "artifactB", "default", "1.0.0", "1.1.0"))));
     }
 }

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextReleasesMojoTest.java
@@ -128,7 +128,8 @@ public class UseNextReleasesMojoTest extends UseLatestVersionsMojoTestBase {
         }
         assertThat(
                 changeRecorder.getChanges(),
-                hasItem(new DefaultDependencyVersionChange("default-group", "dependency-artifact", "1.1.0", "1.1.1")));
+                hasItem(new DefaultDependencyVersionChange(
+                        "default-group", "dependency-artifact", "default", "1.1.0", "1.1.1")));
     }
 
     @Test

--- a/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
+++ b/versions-maven-plugin/src/test/java/org/codehaus/mojo/versions/UseNextVersionsMojoTest.java
@@ -130,7 +130,7 @@ public class UseNextVersionsMojoTest extends UseLatestVersionsMojoTestBase {
         assertThat(
                 changeRecorder.getChanges(),
                 hasItem(new DefaultDependencyVersionChange(
-                        "default-group", "dependency-artifact", "1.1.0-SNAPSHOT", "1.1.1")));
+                        "default-group", "dependency-artifact", "default", "1.1.0-SNAPSHOT", "1.1.1")));
     }
 
     @Test


### PR DESCRIPTION
When two dependencies differ by the classifier only then they appear twice in file `version-changes.xml` but you cannot distinguish which is which.

The general idea is to add the artifact's classifier attribute to node `/updates/dependencyUpdate` when is set:

```
        DependencyVersionChange change = (DependencyVersionChange) changeRecord.getVersionChange();
        update.setAttribute("groupId", change.getGroupId());
        update.setAttribute("artifactId", change.getArtifactId());
        if(change.getClassifier() != null) {
            update.setAttribute("classifier", change.getClassifier());
        }

```

