### PR TITLE
#1331: Fix NPE in restrictionForUnchangedSegment if actual version is null

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/api/AbstractVersionDetails.java
@@ -131,6 +131,7 @@ public abstract class AbstractVersionDetails implements VersionDetails {
         ArtifactVersion nextVersion = selectedSegment
                 .filter(s -> s.isMajorTo(SUBINCREMENTAL))
                 .map(Segment::minorTo)
+                .filter(__ -> highestLowerBound != null)
                 .map(s -> (ArtifactVersion) new BoundArtifactVersion(highestLowerBound, s))
                 .orElse(highestLowerBound);
         return new Restriction(
@@ -138,6 +139,7 @@ public abstract class AbstractVersionDetails implements VersionDetails {
                 false,
                 selectedSegment
                         .filter(MAJOR::isMajorTo)
+                        .filter(__ -> highestLowerBound != null)
                         .map(s -> (ArtifactVersion) new BoundArtifactVersion(highestLowerBound, s))
                         .orElse(null),
                 false);
@@ -157,6 +159,7 @@ public abstract class AbstractVersionDetails implements VersionDetails {
                         .orElse(null)
                 : selectedRestrictionUpperBound;
         ArtifactVersion upperBound = unchangedSegment
+                .filter(__ -> selectedRestrictionUpperBound != null)
                 .map(s -> (ArtifactVersion) new BoundArtifactVersion(
                         selectedRestrictionUpperBound, s.isMajorTo(SUBINCREMENTAL) ? Segment.minorTo(s) : s))
                 .orElse(null);
@@ -174,7 +177,8 @@ public abstract class AbstractVersionDetails implements VersionDetails {
     @Override
     public Restriction restrictionForIgnoreScope(ArtifactVersion lowerBound, Optional<Segment> ignored) {
         ArtifactVersion highestLowerBound = getHighestLowerBound(lowerBound);
-        ArtifactVersion nextVersion = ignored.map(s -> (ArtifactVersion) new BoundArtifactVersion(highestLowerBound, s))
+        ArtifactVersion nextVersion = ignored.filter(__ -> highestLowerBound != null)
+                .map(s -> (ArtifactVersion) new BoundArtifactVersion(highestLowerBound, s))
                 .orElse(highestLowerBound);
         return new Restriction(nextVersion, false, null, false);
     }

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/api/ArtifactVersionsTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
@@ -343,5 +344,35 @@ class ArtifactVersionsTest {
         assertThat(noSnapshots.getVersions(false), arrayWithSize(15));
         assertThat(noSnapshots.getVersions(true), arrayWithSize(15));
         assertThat(noSnapshots.getCurrentVersion(), nullValue());
+    }
+
+    @Test
+    void testRestrictionForUnchangedSegmentIfActualVersionNullAndUpperRestrictionNull() throws InvalidSegmentException {
+        ArtifactVersions versions = new ArtifactVersions(
+                new DefaultArtifact("default-group", "dummy-api", "(,2)", "foo", "bar", "jar", null),
+                Arrays.asList(versions("1.0.0")));
+        assertThat(
+                versions.restrictionForUnchangedSegment(null, Optional.of(MAJOR), false),
+                is(equalTo(new Restriction(null, false, null, false))));
+    }
+
+    @Test
+    void testRestrictionForSelectedSegmentIfLowerBoundNull() throws InvalidSegmentException {
+        ArtifactVersions versions = new ArtifactVersions(
+                new DefaultArtifact("default-group", "dummy-api", "(,)", "foo", "bar", "jar", null),
+                Arrays.asList(versions("1.0.0")));
+        assertThat(
+                versions.restrictionForSelectedSegment(null, Optional.of(MAJOR)),
+                is(equalTo(new Restriction(null, false, null, false))));
+    }
+
+    @Test
+    void testRestrictionForIgnoreScopeLowerBoundNull() throws InvalidSegmentException {
+        ArtifactVersions versions = new ArtifactVersions(
+                new DefaultArtifact("default-group", "dummy-api", "(,)", "foo", "bar", "jar", null),
+                Arrays.asList(versions("1.0.0")));
+        assertThat(
+                versions.restrictionForIgnoreScope(null, Optional.of(MAJOR)),
+                is(equalTo(new Restriction(null, false, null, false))));
     }
 }


### PR DESCRIPTION
A fix for an NPE in an edge case: restrictionForUnchangedSegment(actualVersion, unchangedSegment, allowSnapshots). If actualVersion is a version range with an open upper boundary, unchangedSegment is not empty), then it triggers an NPE.

I tried to limit the scope.