### PR TITLE
set-property should add the property if it does not yet exist

### DIFF
--- a/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/MutableXMLStreamReader.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/MutableXMLStreamReader.java
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.maven.shared.utils.io.IOUtil;
 import org.codehaus.stax2.LocationInfo;
@@ -44,6 +46,7 @@ import static java.util.Optional.ofNullable;
  */
 public class MutableXMLStreamReader extends StreamReader2Delegate implements AutoCloseable {
     private static final XMLInputFactory FACTORY = XMLInputFactory2.newInstance();
+    private static final Pattern INDENTATION_PATTERN = Pattern.compile("^(\\s+)<", Pattern.MULTILINE);
 
     private StringBuilder source;
 
@@ -385,5 +388,36 @@ public class MutableXMLStreamReader extends StreamReader2Delegate implements Aut
         public String toString() {
             return "MarkInfo[" + getStart() + ":" + getEnd() + "]";
         }
+    }
+
+    /**
+     * Determine the line separator.
+     *
+     * @return line separator
+     */
+    public String getLineSeparator() {
+        String text = getSource();
+        if (text.contains("\r\n")) {
+            return "\r\n";
+        }
+        if (text.contains("\r")) {
+            return "\r";
+        }
+        return "\n";
+    }
+
+    /**
+     * Determine the indentation.
+     *
+     * @return indentation
+     */
+    public String getIndentation() {
+        Pattern indentPattern = INDENTATION_PATTERN;
+        Matcher matcher = indentPattern.matcher(getSource());
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return "";
     }
 }

--- a/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/PropertyVersionInternal.java
+++ b/versions-common/src/main/java/org/codehaus/mojo/versions/rewriting/PropertyVersionInternal.java
@@ -1,0 +1,380 @@
+package org.codehaus.mojo.versions.rewriting;
+
+/*
+ * Copyright MojoHaus and Contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * Searches the pom re-defining or inserting the specified version property.
+ * <p>
+ * This is an internal implementation class used by {@link org.codehaus.mojo.versions.api.PomHelper}.
+ * It should not be used directly by client code.
+ *
+ * @since 2.20.1
+ */
+public class PropertyVersionInternal {
+
+    private final MutableXMLStreamReader pom;
+    private final String profileId;
+    private final String propertyName;
+    private final String value;
+    private final String indentation;
+    private final String lineSeparator;
+
+    private Template result = Template.NONE;
+    private boolean inProfileWithId;
+
+    /**
+     * Marks.
+     */
+    private enum Marks {
+        START,
+        END
+    }
+
+    /**
+     * Represents the state of the parser.
+     */
+    private enum State {
+        BEGIN_OF_STREAM,
+        PROJECT,
+        PROFILES,
+        PROFILE,
+        PROFILE_ID,
+        PROPERTIES,
+        PROPERTY,
+        PROJECT_END;
+    }
+
+    /**
+     * Result template.
+     *
+     * Decides what to render between start and end marks.
+     */
+    private enum Template {
+        /**
+         * Does not update anything.
+         */
+        NONE {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                return false;
+            }
+        },
+        /**
+         * Replaces an existing property value.
+         */
+        VALUE {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                pom.replaceBetween(Marks.START, Marks.END, value);
+                return true;
+            }
+        },
+        /**
+         * Inserts a missing property entry at the end of the {@code properties} container.
+         */
+        PROJECT_PROPERTY {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                pom.replaceBetween(
+                        Marks.START,
+                        Marks.END,
+                        String.format(
+                                "%3$s<%1$s>%2$s</%1$s>%4$s%3$s", propertyName, value, indentation, lineSeparator));
+                return true;
+            }
+        },
+        /**
+         * Inserts a missing property entry at the end of the {@code profile}'s {@code properties} container.
+         */
+        PROFILE_PROPERTY {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                pom.replaceBetween(
+                        Marks.START,
+                        Marks.END,
+                        String.format(
+                                "%3$s<%1$s>%2$s</%1$s>%4$s%3$s%3$s%3$s",
+                                propertyName, value, indentation, lineSeparator));
+                return true;
+            }
+        },
+        /**
+         * Inserts a missing property container at the end of the {@code project} element.
+         */
+        PROJECT_PROPERTIES {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                pom.replaceBetween(
+                        Marks.START,
+                        Marks.END,
+                        String.format(
+                                "%3$s<properties>%4$s%3$s%3$s<%1$s>%2$s</%1$s>%4$s%3$s</properties>%4$s",
+                                propertyName, value, indentation, lineSeparator));
+                return true;
+            }
+        },
+        /**
+         * Inserts a missing property container at the end of the {@code profile} element.
+         */
+        PROFILE_PROPERTIES {
+            @Override
+            boolean apply(
+                    MutableXMLStreamReader pom,
+                    String propertyName,
+                    String value,
+                    String indentation,
+                    String lineSeparator) {
+                pom.replaceBetween(
+                        Marks.START,
+                        Marks.END,
+                        String.format(
+                                "%3$s<properties>%4$s%3$s%3$s%3$s%3$s<%1$s>%2$s</%1$s>%4$s%3$s%3$s%3$s</properties>%4$s%3$s%3$s",
+                                propertyName, value, indentation, lineSeparator));
+                return true;
+            }
+        };
+
+        /**
+         * Applies the template.
+         *
+         * @return {@code true} if the pom was modified
+         */
+        abstract boolean apply(
+                MutableXMLStreamReader pom,
+                String propertyName,
+                String value,
+                String indentation,
+                String lineSeparator);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pom          The pom to modify.
+     * @param profileId    The profile in which to modify the property.
+     * @param propertyName The property to modify.
+     * @param value        The new value of the property.
+     */
+    public PropertyVersionInternal(MutableXMLStreamReader pom, String profileId, String propertyName, String value) {
+        this.pom = pom;
+        this.profileId = profileId;
+        this.propertyName = propertyName;
+        this.value = value;
+        this.indentation = pom.getIndentation();
+        this.lineSeparator = pom.getLineSeparator();
+    }
+
+    /**
+     * Perform the actual update operation.
+     *
+     * @param insert Whether to insert a new property or just replace an existing one.
+     * @return {@code true} if the pom was modified
+     * @throws XMLStreamException if something went wrong.
+     */
+    public boolean update(boolean insert) throws XMLStreamException {
+        pom.rewind();
+        result = Template.NONE;
+
+        State state = State.BEGIN_OF_STREAM;
+        while (result == Template.NONE && state != State.PROJECT_END && pom.hasNext()) {
+            pom.next();
+
+            if (pom.isStartElement()) {
+                state = handleStartElement(state, pom.getLocalName());
+            } else if (pom.isEndElement()) {
+                state = handleEndElement(state, pom.getLocalName());
+            } else {
+                if (state != State.PROPERTY) {
+                    pom.mark(Marks.START);
+                }
+            }
+        }
+
+        boolean replaced = false;
+        if (insert || result == Template.VALUE) {
+            replaced = result.apply(pom, propertyName, value, indentation, lineSeparator);
+        }
+
+        pom.clearMark(Marks.START);
+        pom.clearMark(Marks.END);
+        return replaced;
+    }
+
+    private State handleStartElement(State state, String name) throws XMLStreamException {
+        switch (state) {
+            case BEGIN_OF_STREAM:
+                if ("project".equals(name)) {
+                    pom.mark(Marks.START);
+                    return State.PROJECT;
+                }
+                break;
+            case PROJECT:
+                if (profileId == null) {
+                    if ("properties".equals(name)) {
+                        pom.mark(Marks.START);
+                        return State.PROPERTIES;
+                    }
+                } else {
+                    if ("profiles".equals(name)) {
+                        return State.PROFILES;
+                    }
+                }
+                break;
+            case PROFILES:
+                if ("profile".equals(name)) {
+                    return State.PROFILE;
+                }
+                break;
+            case PROFILE:
+                if ("id".equals(name)) {
+                    return handleStartProfileId();
+                }
+                if ("properties".equals(name) && inProfileWithId) {
+                    pom.mark(Marks.START);
+                    return State.PROPERTIES;
+                }
+                break;
+            case PROPERTIES:
+                if (propertyName.equals(name)) {
+                    pom.mark(Marks.START);
+                    return State.PROPERTY;
+                }
+                break;
+            default:
+                break;
+        }
+
+        pom.skipElement();
+        pom.mark(Marks.START);
+        return state;
+    }
+
+    private State handleStartProfileId() throws XMLStreamException {
+        if (profileId.equals(pom.getElementText().trim())) {
+            inProfileWithId = true;
+        }
+        // getElementText could've pushed the pointer to END_ELEMENT
+        if (!pom.isEndElement()) {
+            return State.PROFILE_ID;
+        }
+        pom.mark(Marks.START);
+        return State.PROFILE;
+    }
+
+    private State handleEndElement(State state, String name) {
+        switch (state) {
+            case PROJECT:
+                if ("project".equals(name)) {
+                    return handleEndProject();
+                }
+                break;
+            case PROFILES:
+                if ("profiles".equals(name)) {
+                    return State.PROJECT;
+                }
+                break;
+            case PROFILE:
+                if ("profile".equals(name)) {
+                    return handleEndProfile();
+                }
+                break;
+            case PROFILE_ID:
+                if ("id".equals(name)) {
+                    return State.PROFILE;
+                }
+                break;
+            case PROPERTIES:
+                if ("properties".equals(name)) {
+                    return handleEndProperties();
+                }
+                break;
+            case PROPERTY:
+                if (propertyName.equals(name)) {
+                    return handleEndProperty();
+                }
+                break;
+            default:
+                break;
+        }
+        return state;
+    }
+
+    private State handleEndProject() {
+        if (result == Template.NONE && profileId == null) {
+            pom.mark(Marks.END);
+            result = Template.PROJECT_PROPERTIES;
+        }
+        return State.PROJECT_END;
+    }
+
+    private State handleEndProfile() {
+        if (result == Template.NONE && inProfileWithId) {
+            pom.mark(Marks.END);
+            result = Template.PROFILE_PROPERTIES;
+        }
+
+        inProfileWithId = false;
+        return State.PROFILES;
+    }
+
+    private State handleEndProperties() {
+        if (profileId == null) {
+            if (result == Template.NONE) {
+                pom.mark(Marks.END);
+                result = Template.PROJECT_PROPERTY;
+            }
+            return State.PROJECT;
+        }
+        if (result == Template.NONE) {
+            pom.mark(Marks.END);
+            result = Template.PROFILE_PROPERTY;
+        }
+        return State.PROFILE;
+    }
+
+    private State handleEndProperty() {
+        pom.mark(Marks.END);
+        result = Template.VALUE;
+        return State.PROPERTIES;
+    }
+}

--- a/versions-common/src/test/java/org/codehaus/mojo/versions/rewriting/PropertyVersionInternalTest.java
+++ b/versions-common/src/test/java/org/codehaus/mojo/versions/rewriting/PropertyVersionInternalTest.java
@@ -1,0 +1,199 @@
+package org.codehaus.mojo.versions.rewriting;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PropertyVersionInternalTest {
+
+    @ParameterizedTest
+    @MethodSource("updatablePoms")
+    void testUpdate(String xml, String profileId) throws Exception {
+        MutableXMLStreamReader pom = new MutableXMLStreamReader(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), new File("pom.xml").toPath());
+
+        String oldVersion = "changeit";
+        String newVersion = "1.2.345";
+        boolean modified = new PropertyVersionInternal(pom, profileId, "myVersion", newVersion).update(true);
+        assertTrue(modified);
+
+        String result = pom.getSource();
+
+        assertEquals(1, StringUtils.countMatches(result, "<myVersion>" + newVersion + "</myVersion>"));
+        assertEquals(0, StringUtils.countMatches(result, oldVersion));
+    }
+
+    static Stream<Arguments> updatablePoms() {
+        return Stream.of(
+                Arguments.of(simplePom(), null),
+                Arguments.of(simplePomWithPropertiesEmpty(), null),
+                Arguments.of(simplePomWithProperties(), null),
+                Arguments.of(simplePomWithPropertyExists(), null),
+                Arguments.of(simplePomWithPropertyNotEmpty(), null),
+                Arguments.of(simplePomWithProfile(), null),
+                Arguments.of(simplePomWithProfile(), "myProfile"),
+                Arguments.of(simplePomWithProfileAndPropertiesEmpty(), "myProfile"),
+                Arguments.of(simplePomWithProfileAndProperties(), "myProfile"),
+                Arguments.of(simplePomWithProfileAndPropertyExists(), "myProfile"),
+                Arguments.of(simplePomWithProfileAndPropertyNotEmpty(), "myProfile"),
+                Arguments.of(complexPomWithProfiles(), "myProfile"));
+    }
+
+    static String simplePom() {
+        return "<project></project>";
+    }
+
+    static String simplePomWithPropertiesEmpty() {
+        return "<project>\n" + "  <properties>\n" + "  </properties>\n" + "</project>\n";
+    }
+
+    static String simplePomWithProperties() {
+        return "<project>\n"
+                + "  <properties>\n"
+                + "    <someKey>someValue</someKey>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithPropertyExists() {
+        return "<project>\n"
+                + "  <properties>\n"
+                + "    <someKey>someValue</someKey>\n"
+                + "    <myVersion></myVersion>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithPropertyNotEmpty() {
+        return "<project>\n"
+                + "  <properties>\n"
+                + "    <someKey>someValue</someKey>\n"
+                + "    <myVersion>changeit</myVersion>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithProfile() {
+        return "<project>\n"
+                + "  <profiles>\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithProfileAndPropertiesEmpty() {
+        return "<project>\n"
+                + "  <profiles>\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "      <properties>\n"
+                + "      </properties>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithProfileAndProperties() {
+        return "<project>\n"
+                + "  <profiles>\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "      <properties>\n"
+                + "        <someKey>someValue</someKey>\n"
+                + "      </properties>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithProfileAndPropertyExists() {
+        return "<project>\n"
+                + "  <profiles>\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "      <properties>\n"
+                + "        <someKey>someValue</someKey>\n"
+                + "        <myVersion></myVersion>\n"
+                + "      </properties>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+
+    static String simplePomWithProfileAndPropertyNotEmpty() {
+        return "<project>\n"
+                + "  <profiles>\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "      <properties>\n"
+                + "        <someKey>someValue</someKey>\n"
+                + "        <myVersion>changeit</myVersion>\n"
+                + "      </properties>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+
+    static String complexPomWithProfiles() {
+        return "<project>\n"
+                + "  <!-- Ignore project properties -->\n"
+                + "  <properties>\n"
+                + "    <someKey>someValue</someKey>\n"
+                + "    <myVersion>mustNotChange</myVersion>\n"
+                + "  </properties>\n\n"
+                + "  <!-- Ignore unrelated element -->\n"
+                + "  <build>"
+                + "  </build>\n\n"
+                + "  <profiles>\n"
+                + "    <!-- Ignore this profile -->\n"
+                + "    <profile>\n"
+                + "      <id>someOtherProfile</id>\n"
+                + "      <properties>\n"
+                + "        <myVersion>mustNotChange</myVersion>\n"
+                + "      </properties>\n"
+                + "    </profile>\n\n"
+                + "    <profile>\n"
+                + "      <id>myProfile</id>\n"
+                + "      <!-- Ignore unrelated element -->\n"
+                + "      <activation>\n"
+                + "        <activeByDefault>false</activeByDefault>\n"
+                + "      </activation>\n"
+                + "      <properties>\n"
+                + "        <someKey>someOtherValue</someKey>\n"
+                + "        <myVersion>changeit</myVersion>\n"
+                + "      </properties>\n"
+                + "    </profile>\n"
+                + "  </profiles>\n"
+                + "</project>\n";
+    }
+}

--- a/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
+++ b/versions-maven-plugin/src/main/java/org/codehaus/mojo/versions/SetPropertyMojo.java
@@ -97,6 +97,14 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
     private String profileId = null;
 
     /**
+     * Whether to insert a new version property or just replace an existing one.
+     *
+     * @since 2.21
+     */
+    @Parameter(property = "insert", defaultValue = "false")
+    private boolean insert;
+
+    /**
      * Whether to allow snapshots when searching for the latest version of an artifact.
      *
      * @since 1.0-alpha-1
@@ -201,7 +209,7 @@ public class SetPropertyMojo extends AbstractVersionsUpdaterMojo {
                 continue;
             }
             PomHelper.setPropertyVersion(
-                    pom, profileToApply, currentProperty.getName(), defaultString(newVersionGiven));
+                    pom, profileToApply, currentProperty.getName(), defaultString(newVersionGiven), insert);
         }
     }
 

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/issue-1268/child/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/issue-1268/child/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>group</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>child</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>${dummy-api-version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/issue-1268/pom.xml
+++ b/versions-maven-plugin/src/test/resources/org/codehaus/mojo/set-property/issue-1268/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>child</module>
+    </modules>
+    <properties>
+        <dummy-api-version>2.0</dummy-api-version>
+    </properties>
+</project>


### PR DESCRIPTION
Fixes #1268

* instead of just updating existing properties allows to insert ~completely new properties~ new properties overriding properties from parent POM
* works for properties on the project level as well as on the profile level (that is if a profile id is given)
* though this implementation won't create new profiles at the moment, this could be a possible enhancement, let me know if this sounds useful
* formatting was kind of a challenge

*Usage*
```
mvn org.codehaus.mojo:versions-maven-plugin:2.21.1-SNAPSHOT:set-property \
  -Dproperty=mockitoVersion \
  -DnewVersion=4.11.1 \
  -Dinsert
```

Notice that set-properties will be executed recursively on child modules if there are any.
If you don't want the property to be inserted into all of these child modules use the `-N` option.