### PR TITLE
docs(markdown): fix grammar, typos, and markup in .md.vm files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is the [versions-maven-plugin](http://www.mojohaus.org/versions-maven-plugi
 
 ## Maintained versions
 
-Versions Maven Plugin requires Maven 3.6.3+ and JDK 1.8+
+Versions Maven Plugin requires Maven 3.6.3+ and JDK 1.8+.
 
-However, we maintain the latest Plugin version with the latest Maven.
+However, we maintain the latest plugin version alongside the latest Maven release.
 
 We execute tests against different operating systems and JDKs
 by [GitHub Actions](https://github.com/mojohaus/versions-maven-plugin/actions/workflows/maven.yml?query=branch%3Amaster)
@@ -19,26 +19,25 @@ by [GitHub Actions](https://github.com/mojohaus/versions-maven-plugin/actions/wo
 
 ### Creating Issues
 
-If you find a problem please first search current opened and closed issues and pull requests.
-It can be that someone already has reported similar.
+If you find a problem, please first search the current open and closed issues and pull requests.
+Someone may have already reported a similar issue.
 
-You can also check current [milestone](https://github.com/mojohaus/versions-maven-plugin/milestones)
-in order to see what will be in next release.
+You can also check the current [milestone](https://github.com/mojohaus/versions-maven-plugin/milestones)
+to see what will be in the next release.
 
-Only when you can not find similar issue please create a new one in the
+Only if you cannot find a similar issue, please create a new one in the
 [ticket system](https://github.com/mojohaus/versions-maven-plugin/issues)
 and describe what is going wrong or what you expect to happen.
 
-If you have a full working example or a log file this is also helpful.
+If you have a full working example or a log file, this is also helpful.
 
-You should of course describe only a single issue in a single ticket and not
-mixing up several things into a single issue.
+Describe only a single issue per ticket; do not mix several issues into one.
 
 Please always check your issue with the latest Plugin and the latest Maven version.
 
 ### Creating a Pull Request
 
-Before you start working on more complicated change, new feature
+Before working on a more complicated change or new feature,
 it is good practice to create an issue in
 the [ticket system](https://github.com/mojohaus/versions-maven-plugin/issues)
 or send an email to [development list](https://www.mojohaus.org/versions-maven-plugin/mailing-lists.html)
@@ -46,27 +45,24 @@ and describe what the problem is or what kind of feature you would like to add.
 Wait a few days for feedback from other contributors.
 Afterwards you can create an appropriate pull request.
 
-It is required if you want to get a pull request to be integrated into please
-squash your commits into a single commit which references the optional issue
-in the commit message which looks like this:
+To have a pull request integrated, please squash your commits into a single commit
+that references the issue in the commit message, for example:
 
-```
-Fixed #Issue - change subject 
+```text
+Fixed #Issue - change subject
 
 a description
 ```
 
-Please take into consideration that change subject will be used in release notes
-and will be present in git history so should be enough descriptive.
+Note that the commit subject will be used in release notes and preserved in Git history,
+so it should be sufficiently descriptive.
 
-This makes it simpler to merge it and this will also close the
-appropriate issue automatically in one go.
-This makes the life as maintainer a little bit easier.
+This simplifies merging and automatically closes the related issue. It also makes life
+as a maintainer a little easier.
 
-A pull request has to fulfill only a single ticket and should never
-create/add/fix several issues in one, cause otherwise the history is hard to
-read and to understand and makes the maintenance of the issues and pull request
-hard or to be honest impossible.
+A pull request must address only a single ticket and should never create, add, or fix
+several issues at once, as otherwise the history is hard to read and maintenance of
+issues and pull requests becomes very difficult.
 
 ## Releasing
 
@@ -75,10 +71,10 @@ hard or to be honest impossible.
 
 For publishing the site do the following:
 
-```
+```shell
 cd target/checkout
 mvn site
 mvn scm-publish:publish-scm
 ```
 
-for multi module site - we need two executions
+For a multi-module site, two executions are needed.

--- a/versions-api/src/site/markdown/change-recorder.md.vm
+++ b/versions-api/src/site/markdown/change-recorder.md.vm
@@ -1,9 +1,9 @@
-title: Writing a own ChangeRecorder
+title: Writing Your Own ChangeRecorder
 author: Slawomir Jaranowski
 date: 2022-11-20
 
-Writing an own ChangeRecorder
-============================
+Writing Your Own ChangeRecorder
+================================
 
 In order to create an own ChangeRecorder you must implement [ChangeRecorder](apidocs/org/codehaus/mojo/versions/api/recording/ChangeRecorder.html) interface.
 
@@ -40,7 +40,7 @@ public class MyChangeRecorder implements ChangeRecorder {
 }
 ```
 
-`Changerecoder` is stateful component, so you must not add `Singleton` annotation to it.
+`ChangeRecorder` is a stateful component, so you must not add the `Singleton` annotation to it.
 
 Using extension
 ---------------
@@ -86,7 +86,7 @@ Plugin configuration:
 
 Now execution like:
 
-```
+```shell
 mvn versions:update-properties
 ```
 

--- a/versions-api/src/site/markdown/index.md.vm
+++ b/versions-api/src/site/markdown/index.md.vm
@@ -1,11 +1,11 @@
-title: Writing an extensions for Versions Plugin
+title: Writing Extensions for the Versions Plugin
 author: Slawomir Jaranowski
 date: 2022-11-20
 
-Writing an extensions for Versions Plugin
-========================================
+Writing Extensions for the Versions Plugin
+==========================================
 
-`Versions API` allow you write extension for `Versions Plugin`.
+`Versions API` allows you to write extensions for `Versions Plugin`.
 
 Project template for extensions
 -------------------------------
@@ -62,13 +62,13 @@ Your Maven project should look like:
 
 Note that the classloader is shared with the `versions-maven-plugin` [plugin classloader](https://maven.apache.org/guides/mini/guide-maven-classloading.html#plugin-classloaders)
 
-The artifacts `org.codehaus.mojo.versions:versions-api` and `javax.inject:javax.inject` are always loaded in the same version as used `versions-maven-plugin` use.
+The artifacts `org.codehaus.mojo.versions:versions-api` and `javax.inject:javax.inject` are always loaded in the same version as the one used by `versions-maven-plugin`.
 
 Extension artifact should therefore only depend on them with `provided` scope.
 
 
-Using extensions with Version Maven Plugin
-------------------------------------------
+Using Extensions with the Versions Maven Plugin
+------------------------------------------------
 
 You need to add your extension as plugin dependency:
 

--- a/versions-enforcer/src/site/markdown/index.md.vm
+++ b/versions-enforcer/src/site/markdown/index.md.vm
@@ -69,7 +69,7 @@ will match all artifacts with groupId `org.codehaus.mojo`.
 
 ### Sample Plugin Configuration
 
-Below a rundimentary example of using the enforcer rule.
+Below is a rudimentary example of using the enforcer rule.
 
 The below example specifies a rule which will not allow any updates except for updates of `localhost:dummy-api`.
 It will also ignore all sub-incremental updates.

--- a/versions-maven-plugin/src/site/markdown/examples/advancing-dependency-versions.md.vm
+++ b/versions-maven-plugin/src/site/markdown/examples/advancing-dependency-versions.md.vm
@@ -24,18 +24,18 @@ Advancing dependency versions
 
 There are a number of goals which can be used to advance dependency versions:
 
-- [versions:use-next-releases](../use-next-releases-mojo.html) searches the pom for all non-SNAPSHOT versions which
-have been a newer release and replaces them with the next release version.
-- [versions:use-latest-releases](../use-latest-releases-mojo.html) searches the pom for all non-SNAPSHOT versions
-which have been a newer release and replaces them with the latest release version.
-- [versions:use-next-snapshots](../use-next-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions 
-which have been a newer -SNAPSHOT version and replaces them with the next -SNAPSHOT version.
-- [versions:use-latest-snapshots](../use-latest-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions 
-which have been a newer -SNAPSHOT version and replaces them with the latest -SNAPSHOT version.
-- [versions:use-next-versions](../use-next-versions-mojo.html) searches the pom for all versions which
-have been a newer version and replaces them with the next version.
- [versions:use-latest-versions](../use-latest-versions-mojo.html) searches the pom for all versions which
-have been a newer version and replaces them with the latest version.
+- [versions:use-next-releases](../use-next-releases-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer release is available, and replaces them with the next release version.
+- [versions:use-latest-releases](../use-latest-releases-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer release is available, and replaces them with the latest release version.
+- [versions:use-next-snapshots](../use-next-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer -SNAPSHOT version is available, and replaces them with the next -SNAPSHOT version.
+- [versions:use-latest-snapshots](../use-latest-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer -SNAPSHOT version is available, and replaces them with the latest -SNAPSHOT version.
+- [versions:use-next-versions](../use-next-versions-mojo.html) searches the pom for all versions for
+which a newer version is available, and replaces them with the next version.
+- [versions:use-latest-versions](../use-latest-versions-mojo.html) searches the pom for all versions for
+which a newer version is available, and replaces them with the latest version.
 
 All of these goals share a common set of parameters.
 
@@ -61,7 +61,7 @@ are for release versions (i.e. non-SNAPSHOT versions).
 are for -SNAPSHOT versions.
 - *Considers releases* when building the list of newer versions of a dependency, include release versions (i.e. non-SNAPSHOT
 versions) in the list.
-- *Considers releases* when building the list of newer versions of a dependency, include -SNAPSHOT versions in the list.
+- *Considers -SNAPSHOTs* when building the list of newer versions of a dependency, include -SNAPSHOT versions in the list.
 - *Picks Next* when the list of newer versions is sorted in increasing order, pick the first newer version in the list, i.e.
 the oldest newer version available, also known as the "next" version.
 - *Picks Latest* when the list of newer versions is sorted in increasing order, pick the last newer version in the list, i.e.

--- a/versions-maven-plugin/src/site/markdown/examples/compare-dependencies.md
+++ b/versions-maven-plugin/src/site/markdown/examples/compare-dependencies.md
@@ -50,7 +50,7 @@ of one of several artifacts can be updated to match the remote project using the
 parameter. By default, this is turned off.
 
 ```sh
-mvn versions:compare-dependencies -DremotePom=org.foo:bom-pom:1.0 -updatePropertyVersions=true
+mvn versions:compare-dependencies -DremotePom=org.foo:bom-pom:1.0 -DupdatePropertyVersions=true
 ```
 
 Such update will only occur if the dependencies linked to that version exist in the remote project

--- a/versions-maven-plugin/src/site/markdown/examples/display-dependency-updates.md.vm
+++ b/versions-maven-plugin/src/site/markdown/examples/display-dependency-updates.md.vm
@@ -36,7 +36,7 @@ mvn versions:$goal
 
 Which produces the following output:
 
-```sh
+```log
 [INFO] ------------------------------------------------------------------------
 [INFO] Building Build Helper Maven Plugin
 [INFO]    task-segment: [versions:display-dependency-updates]
@@ -106,7 +106,7 @@ $h3 Difference between *ignoredVersions* or *ruleSet* and *dependencyExcludes*
 
 You might wonder when to use *ignoredVersions* or *ruleSet* versus *dependencyExcludes*.
 
-As said before, *dependencyExcludes* target the version **before the upgrade** while *ignoredVersions* or *ruleSet* filter the possible upgrades.
+As mentioned above, *dependencyExcludes* target the version **before the upgrade** while *ignoredVersions* or *ruleSet* filter the possible upgrades.
 
 | Option             | Applies to…                                         | Typical use case                                               |
 |--------------------|-----------------------------------------------------|----------------------------------------------------------------|
@@ -127,7 +127,7 @@ Our project has a couple build plugins, which are defined with dependencies to `
   <plugins>
     <plugin>
       <groupId>com.mygroup</groupId>
-      <artifact>myartifact</artifact>
+      <artifactId>myartifact</artifactId>
       <version>1.10.2</version>
       <dependencies>
         <dependency>

--- a/versions-maven-plugin/src/site/markdown/examples/display-plugin-updates.md.vm
+++ b/versions-maven-plugin/src/site/markdown/examples/display-plugin-updates.md.vm
@@ -202,7 +202,7 @@ produces the following output (when run using Maven 2.0.6):
 [INFO] ------------------------------------------------------------------------
 ```
 
-Note: that because the POM does not specify versions for some plugins, Maven
+Note that because the POM does not specify versions for some plugins, Maven
 defaults to using the latest compatible version (Maven 3 complains about the
 version not being specified), and hence the reported minimum required Maven
 version tends to be the same as the version of Maven that is running the mojo
@@ -350,7 +350,7 @@ produces the following output:
 [INFO] Final Memory: 17M/81M
 [INFO] ------------------------------------------------------------------------
 ```
-<!--- Ignoring specific version suffixes -->
+<!-- Ignoring specific version suffixes -->
 
 #parse( "ignore-versions.md.vm" )
 

--- a/versions-maven-plugin/src/site/markdown/examples/ignore-versions.md.vm
+++ b/versions-maven-plugin/src/site/markdown/examples/ignore-versions.md.vm
@@ -1,7 +1,7 @@
 Ignoring specific version suffixes
 ----------------------------------
 
-Let's suppose you wanted `org.apache.maven.doxia:doxia-core:` not to be updated to `2.0.0-M6` or `org.apache.maven:maven-core` to `4.0.0-alpha-5'` or anything with a `-M` or `-alpha` in it.
+Let's suppose you wanted `org.apache.maven.doxia:doxia-core` not to be updated to `2.0.0-M6` or `org.apache.maven:maven-core` to `4.0.0-alpha-5` or anything with a `-M` or `-alpha` in it.
 
 You can either use `ruleSet` or `ignoredVersions`.
 
@@ -49,19 +49,19 @@ $h3 Using ruleSet (more control)
 </configuration>
 ```
 
-See also: [Version rules](../version-rules.md.vm)
+See also: [Version rules](../version-rules.html)
 
 $h3 Output with ignored versions
 
 Instead of:
 
-```
+```log
 org.apache.maven:maven-core ........ 3.2.5 -> 4.0.0-alpha-5
 ```
 
 You will only see stable updates:
 
-```
+```log
 org.apache.maven:maven-core ........ 3.2.5 -> 3.9.2
 ```
 

--- a/versions-maven-plugin/src/site/markdown/examples/lock-snapshots.md
+++ b/versions-maven-plugin/src/site/markdown/examples/lock-snapshots.md
@@ -81,11 +81,11 @@ artifactId matching "junit".
 mvn versions:lock-snapshots -Dincludes=org.codehaus.plexus:*,junit:junit
 ```
 
-By default, both the `project/dependencyManagment` and `project/dependencies` sections will be processed.
+By default, both the `project/dependencyManagement` and `project/dependencies` sections will be processed.
 You can use the `processDependencies` and `processDependencyManagement` parameters to control which sections
 are processed.
 
-This example will only process the `project/dependencyManagment` section of your pom:
+This example will only process the `project/dependencyManagement` section of your pom:
 
 ```sh
 mvn versions:lock-snapshots -DprocessDependencies=false

--- a/versions-maven-plugin/src/site/markdown/examples/resolve-ranges.md
+++ b/versions-maven-plugin/src/site/markdown/examples/resolve-ranges.md
@@ -99,11 +99,11 @@ artifactId matching "junit".
 mvn versions:resolve-ranges -Dincludes=org.codehaus.plexus:*,junit:junit
 ```
 
-By default, both the `project/dependencyManagment` and `project/dependencies` sections will be processed.
+By default, both the `project/dependencyManagement` and `project/dependencies` sections will be processed.
 You can use the `processDependencies` and `processDependencyManagement` parameters to control which sections
 are processed.
 
-This example will only process the `project/dependencyManagment` section of your pom:
+This example will only process the `project/dependencyManagement` section of your pom:
 
 ```sh
 mvn versions:resolve-ranges -DprocessDependencies=false

--- a/versions-maven-plugin/src/site/markdown/examples/setaggregator.md
+++ b/versions-maven-plugin/src/site/markdown/examples/setaggregator.md
@@ -184,9 +184,9 @@ mvn versions:set -DnewVersion=3.6.0 -DoldVersion=* -DgroupId=* -DartifactId=*
 ```
 
 This is needed otherwise the filter for the versions (via `-DoldVersion=*`) would have
-filtered out that module cause it has a different version than the rest of modules.
+filtered out that module because it has a different version than the rest of the modules.
 Furthermore, you need to add the `-DgroupId=*` and `-DartifactId=*` otherwise
-the `separate-module` will also filtered out based on the differences in groupId
+the `separate-module` will also be filtered out based on the differences in groupId
 and artifactId.
 
 So in end the result of the above call looks like this:

--- a/versions-maven-plugin/src/site/markdown/examples/unlock-snapshots.md
+++ b/versions-maven-plugin/src/site/markdown/examples/unlock-snapshots.md
@@ -82,11 +82,11 @@ artifactId matching "junit".
 mvn versions:unlock-snapshots -Dincludes=org.codehaus.plexus:*,junit:junit
 ```
 
-By default, both the `project/dependencyManagment` and `project/dependencies` sections will be processed.
+By default, both the `project/dependencyManagement` and `project/dependencies` sections will be processed.
 You can use the `processDependencies` and `processDependencyManagement` parameters to control which sections
 are processed.
 
-This example will only process the `project/dependencyManagment` section of your pom:
+This example will only process the `project/dependencyManagement` section of your pom:
 
 ```shell
 mvn versions:unlock-snapshots -DprocessDependencies=false

--- a/versions-maven-plugin/src/site/markdown/examples/update-properties.md.vm
+++ b/versions-maven-plugin/src/site/markdown/examples/update-properties.md.vm
@@ -89,7 +89,7 @@ which depends on evaluating a single property that is defined in the POM, for ex
     </dependency>
 ```
 
-If multiple dependencies use the property to define the version, then the all dependencies will be used to determine
+If multiple dependencies use the property to define the version, then all dependencies will be used to determine
 what versions are available (and consequently what version to update the property to).  The version chosen in such 
 cases must be available for all associated dependencies.
 
@@ -136,7 +136,7 @@ for example if we add the following to the POM:
 ```
 
 Then executing the `update-properties` goal will update the `manchu.version` property to the latest common 
-version of both manchu-core and manchu-wibble available to  you (i.e. based on your local repository and all 
+version of both manchu-core and manchu-wibble available to you (i.e. based on your local repository and all 
 currently active remote repositories).
 
 If you want to restrict updates to within a specific range, for example, suppose we only want the 1.5 stream of
@@ -176,7 +176,7 @@ manchu:
 </project>
 ```
 
-Additionally, if you want to disable the automatic detection of properties set the autoLinkItemDependencies to false
+Additionally, if you want to disable automatic property detection, set `autoLinkDependencies` to `false`:
 
 ```xml
 <project>
@@ -250,7 +250,7 @@ If you want to disable the preference given to the reactor (i.e. stop the reacto
 </project>
 ```
 
-If you want to disable the searching the reactor at all:
+If you want to disable searching the reactor entirely:
 
 ```xml
 <project>
@@ -286,8 +286,8 @@ If you want to disable the searching the reactor at all:
 </project>
 ```
 
-The allowSnapshots property and configuration option allow the inclusion of snapshots, if you want to ensure that
-snapshots are *never* resolved,
+The `allowSnapshots` property and configuration option allow the inclusion of snapshots; if you want to ensure that
+snapshots are *never* resolved for a specific property:
 
 ```xml
 <project>
@@ -327,7 +327,7 @@ snapshots are *never* resolved,
 
 ## Restricting the properties to be updated using includes / excludes
 
-The **includes** and **excludes` parameters follow the format `groupId:artifactId:type:classifier`.
+The `includes` and `excludes` parameters follow the format `groupId:artifactId:type:classifier`.
 Use a comma separated list to specify multiple includes.  Wildcards (*) can also be used to match
 multiple values.
 

--- a/versions-maven-plugin/src/site/markdown/examples/use-releases.md
+++ b/versions-maven-plugin/src/site/markdown/examples/use-releases.md
@@ -77,11 +77,11 @@ artifactId matching "junit".
 mvn versions:use-releases -Dincludes=org.codehaus.plexus:*,junit:junit
 ```
 
-By default, both the `project/dependencyManagment` and `project/dependencies` sections will be processed.
+By default, both the `project/dependencyManagement` and `project/dependencies` sections will be processed.
 You can use the `processDependencies` and `processDependencyManagement` parameters to control which sections
 are processed.
 
-This example will only process the `project/dependencyManagment` section of your pom:
+This example will only process the `project/dependencyManagement` section of your pom:
 
 ```shell
 mvn versions:use-releases -DprocessDependencies=false

--- a/versions-maven-plugin/src/site/markdown/faq.md
+++ b/versions-maven-plugin/src/site/markdown/faq.md
@@ -24,7 +24,7 @@ under the License.
 
 ### What does the Versions Maven Plugin do?
 
-The Versions Maven Plugin provides a means to update version information in a Maven project
+The Versions Maven Plugin provides a means to update version information in a Maven project.
 
 ### Why is this plugin reporting version 1.0.0.9 of foo:bar as the latest version when I can see version 1.0.0.23?
 
@@ -71,7 +71,7 @@ rebuild the metadata files based on the artifacts that are present.
 
 The reason for that is that the option filters *input* dependency versions.
 
-Let's suppose you wanted `org.apache.maven.doxia:doxia-core:` not to be updated to `2.0.0-M6` or `org.apache.maven:maven-core` to `4.0.0-alpha-5'  or anything with a `-M` or `-alpha' in it. Upon first sight of the `dependencyExcludes` option, one might consider to use it to filter out anything with `2.*-M.*` or `*-alpha.*`.
+Let's suppose you wanted `org.apache.maven.doxia:doxia-core` not to be updated to `2.0.0-M6` or `org.apache.maven:maven-core` to `4.0.0-alpha-5` or anything with a `-M` or `-alpha` in it. Upon first sight of the `dependencyExcludes` option, one might consider using it to filter out anything with `2.*-M.*` or `*-alpha.*`.
 
 Well, that would be wrong. `dependencyIncludes` and `dependencyExcludes` work only on *input* dependencies, that is, dependency versions that are already being used by your project. This means that it is likely that you will still see the dreaded `2.0.0-M6`-like version in the updates.
 

--- a/versions-maven-plugin/src/site/markdown/index.md
+++ b/versions-maven-plugin/src/site/markdown/index.md
@@ -57,17 +57,17 @@ to the specific version being used.
 * [versions:set-property](./set-property-mojo.html) can be used to set one or multiple properties to a given version from the command line.
 * [versions:use-releases](./use-releases-mojo.html) searches the pom for all -SNAPSHOT versions which have been
 released and replaces them with the corresponding release version.
-* [versions:use-next-releases](./use-next-releases-mojo.html) searches the pom for all non-SNAPSHOT versions which
-have been a newer release and replaces them with the next release version.
+* [versions:use-next-releases](./use-next-releases-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer release is available, and replaces them with the next release version.
 * [versions:use-latest-releases](./use-latest-releases-mojo.html) searches the pom for all dependencies using *release* versions (i.e. not SNAPSHOT and not versions ending with a year-month-day suffix) and replaces them with the latest *release* version.
-* [versions:use-next-snapshots](./use-next-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions which
-have been a newer -SNAPSHOT version and replaces them with the next -SNAPSHOT version.
-* [versions:use-latest-snapshots](./use-latest-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions
-which have been a newer -SNAPSHOT version and replaces them with the latest -SNAPSHOT version.
-* [versions:use-next-versions](./use-next-versions-mojo.html) searches the pom for all versions which
-have been a newer version and replaces them with the next version.
-* [versions:use-latest-versions](./use-latest-versions-mojo.html) searches the pom for all versions which
-have been a newer version and replaces them with the latest version.
+* [versions:use-next-snapshots](./use-next-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer -SNAPSHOT version is available, and replaces them with the next -SNAPSHOT version.
+* [versions:use-latest-snapshots](./use-latest-snapshots-mojo.html) searches the pom for all non-SNAPSHOT versions for
+which a newer -SNAPSHOT version is available, and replaces them with the latest -SNAPSHOT version.
+* [versions:use-next-versions](./use-next-versions-mojo.html) searches the pom for all versions for
+which a newer version is available, and replaces them with the next version.
+* [versions:use-latest-versions](./use-latest-versions-mojo.html) searches the pom for all versions for
+which a newer version is available, and replaces them with the latest version.
 * [versions:use-dep-version](./use-dep-version-mojo.html) updates a dependency to a specific version.
 * [versions:commit](./commit-mojo.html) removes the `pom.xml.versionsBackup` files. Forms one half of the
 built-in "Poor Man's SCM".
@@ -80,7 +80,7 @@ The Versions Plugin has the following reporting goals.
 * [versions:dependency-updates-report](./dependency-updates-report-mojo.html) produces a report of those
 project dependencies which have newer versions available.
 * [versions:dependency-updates-aggregate-report](./dependency-updates-aggregate-report-mojo.html) produces an aggregated
-report(project + its submodules) of those dependencies which have newer versions available.
+report (project + its submodules) of those dependencies which have newer versions available.
 * [versions:plugin-updates-report](./plugin-updates-report-mojo.html) produces a report of those plugins which have
 newer versions available.
 * [versions:plugin-updates-aggregate-report](./plugin-updates-aggregate-report-mojo.html) produces an aggregated report
@@ -88,7 +88,7 @@ newer versions available.
 * [versions:property-updates-report](./property-updates-report-mojo.html) produces a report of
 those properties which are used to control artifact versions and which properties have newer versions available.
 * [versions:property-updates-aggregate-report](./property-updates-aggregate-report-mojo.html) produces an aggregated
-report(project + its submodules) of those properties which are used to control artifact versions and
+report (project + its submodules) of those properties which are used to control artifact versions and
 which properties have newer versions available.
 * [versions:parent-updates-report](./parent-updates-report-mojo.html) produces a report on possible parent artifact
 upgrades.
@@ -105,14 +105,14 @@ General instructions on how to use the Versions Plugin can be found on the [usag
 specific use cases are described in the examples given below.
 
 In case you still have questions regarding the plugin's usage, please have a look at the [FAQ](./faq.html) and feel
-free to post a question on our [Github issue tracker](./issue-management.html) or contact
-the [user mailing list](./mailing-lists.html). The posts to Github or the mailing list are archived and could
+free to post a question on our [GitHub issue tracker](./issue-management.html) or contact
+the [user mailing list](./mailing-lists.html). The posts to GitHub or the mailing list are archived and could
 already contain the answer to your question as part of an older thread.
 
 For older issues, it is also worth browsing/searching the [mail archive](./mail-lists.html).
 
 If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
-[Github issue tracker](./issue-management.html). When creating a new issue, please provide a comprehensive description
+[GitHub issue tracker](./issue-management.html). When creating a new issue, please provide a comprehensive description
 of your concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this
 reason, entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
 Of course, patches are welcome, too. Contributors can check out the project from our
@@ -121,7 +121,7 @@ Of course, patches are welcome, too. Contributors can check out the project from
 
 ## Examples
 
-To provide you with better understanding of some usages of the Plugin Name,
+To provide you with a better understanding of some usages of the Versions Plugin,
 you can take a look into the following examples:
 * [Advancing dependency versions](./examples/advancing-dependency-versions.html)
 * [Compare project dependencies to a remote project](./examples/compare-dependencies.html)

--- a/versions-maven-plugin/src/site/markdown/usage.md.vm
+++ b/versions-maven-plugin/src/site/markdown/usage.md.vm
@@ -105,7 +105,7 @@ match the version specified in the parent section of the child modules, Maven wi
 To fix all the child modules, use the [versions:update-child-modules](./update-child-modules-mojo.html) goal and
 invoke Maven in non-recursive mode.
 
-```
+```shell
 mvn -N versions:update-child-modules
 ```
 
@@ -177,7 +177,7 @@ goal.
 mvn versions:use-releases
 ```
 
-More examples of the [`lock-snapshots`](./examples/use-releases.html) goal.
+More examples of the [`use-releases`](./examples/use-releases.html) goal.
 
 $h3  Setting the project version
 
@@ -215,7 +215,7 @@ mvn versions:display-dependency-updates
 
 [A more detailed example of the `display-dependency-updates` goal](./examples/display-dependency-updates.html).
 
-$h3  Checking for new versions of specified by properties
+$h3  Checking for new versions specified by properties
 
 To get information about newer versions of dependencies that you are using in your build, just invoke the
 `display-property-updates` goal.

--- a/versions-maven-plugin/src/site/markdown/version-rules.md.vm
+++ b/versions-maven-plugin/src/site/markdown/version-rules.md.vm
@@ -95,7 +95,7 @@ Note: the `groupId` attribute in the `rule` elements has a lazy `.*` at the end,
 $h3 Using the `ruleSet` element in the POM
 
 As an alternative to providing a separate `rules.xml` file, starting with version `2.13.0` it is possible
-to provide the `ruleSet` element directly in the POM. The structure is somewhat simpler to
+to provide the `ruleSet` element directly in the POM. The structure is somewhat similar to
 the `rules.xml` file:
 
 ```xml
@@ -139,7 +139,7 @@ the `rules.xml` file:
               <!-- if provided, restricts the groupId for the rule -->
               <groupId>org.codehaus.mojo</groupId>
 
-              <!-- if provided,
+              <!-- if provided, restricts the artifactId for the rule -->
               <artifactId>versions-maven-plugin</artifactId>
 
               <!-- syntax the same as for the general ignoreVersions -->
@@ -165,8 +165,8 @@ $h3 Ignoring certain versions
 
 It is possible to ignore versions on a global and on a per-rule basis.
 
-The other methods (via the `<ruleSet>` element and via the `maven.version.ignore`) property have been
-explained above. The described
+The other methods—via the `<ruleSet>` element and the `maven.version.ignore` property—have been
+explained above. The `rules.xml` example below demonstrates both global and per-rule version ignoring:
 
 ```xml
 <ruleset xmlns="https://www.mojohaus.org/VERSIONS/RULE/3.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
## Summary
Fixes grammar, typos, broken markup, and two functional documentation errors across all .md.vm template files and the main index.md.

## Changes

### Functional documentation fixes (incorrect behaviour if copy-pasted):
 - `display-dependency-updates.md.vm` — `<artifact>myartifact</artifact>` → `<artifactId>myartifact</artifactId>` (invalid Maven POM element)
 - `usage.md.vm` — Link text `lock-snapshots` pointing at `use-releases.html` corrected to `use-releases`
 - `ignore-versions.md.vm` — Internal link `../version-rules.md.vm` → `../version-rules.html` (raw template path exposed in generated HTML)
 - `update-properties.md.vm` — `autoLinkItemDependencies` → `autoLinkDependencies` (references a non-existent parameter name)

### Grammar and language fixes:
 - `change-recorder.md.vm` — "Writing a own" → "Writing Your Own"; "Changerecoder is stateful component" → "ChangeRecorder is a stateful component"
 - `versions-api/index.md.vm` — "Writing an extensions" → "Writing Extensions"; "allow you write extension" → "allows you to write extensions"; "as used versions-maven-plugin use" → "as the one used by versions-maven-plugin"; 
"Version Maven Plugin" → "the Versions Maven Plugin"
 - `advancing-dependency-versions.md.vm` + `index.md` — Six goal descriptions: "which have been a newer X" → "for which a newer X is available" (grammatically incorrect in all occurrences)
 - `advancing-dependency-versions.md.vm` — Duplicate column header "Considers releases" → "Considers -SNAPSHOTs" in goal matrix; missing -  list bullet on use-latest-versions
 - `versions-enforcer/index.md.vm` — "Below a rundimentary example" → "Below is a rudimentary example"
 - `update-properties.md.vm` — "then the all dependencies"; double space; "disable the searching the reactor at all"; trailing comma → semicolon on allowSnapshots sentence
 - `display-dependency-updates.md.vm` — "As said before" → "As mentioned above"
 - `usage.md.vm` — Heading "Checking for new versions of specified by" → "specified by"
 - `version-rules.md.vm` — "somewhat simpler to" → "somewhat similar to"; incomplete sentence "The described" completed; broken XML comment <!-- if provided, closed and annotated

### Markdown syntax fixes:
 - `update-properties.md.vm` — Mixed **bold**/`backtick` syntax on includes/excludes → consistent backticks
 - `display-plugin-updates.md.vm` — Invalid <!--- triple-dash comment → <!--; "Note: that" → "Note that"
 - `ignore-versions.md.vm` — Two bare code fences for log output → ```log
 - `change-recorder.md.vm` + `usage.md.vm` — Bare code fences for shell commands → ```shell

## Motivation
Several `.md.vm` template files had accumulated issues ranging from copy-paste errors and broken parameter names to grammatically incorrect goal descriptions repeated across multiple files. The two most impactful were the invalid 
<artifact> POM element (users copying the example would get a Maven parse error) and the autoLinkItemDependencies reference to a parameter that does not exist in the plugin.

## Impact
 - Documentation readers and users only — no source code changes
 - The `<artifactId>` and `autoLinkDependencies` corrections fix examples that were silently wrong
 - The `version-rules.html` link fix prevents a broken link in the generated site
 - All other changes are purely editorial; meaning and intent are preserved throughout

## Testing
Documentation-only changes. Verified by inspecting each modified file to confirm no unintended changes to code samples, link targets, or Velocity macro syntax (#set, #parse, $h3, etc.).

## Notes
 - The goal matrix table in `advancing-dependency-versions.md.vm` has a separate pre-existing structural issue (blank vs. Yes cells for use-next-releases/use-latest-releases) that requires semantic clarification from the plugin 
maintainers; it has not been changed here